### PR TITLE
Disable hyper default features for openssl deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ version = "0.3"
 
 [dependencies.hyper]
 optional = true
+default-features = false
 version = "0.9"
 
 [dependencies.iron]


### PR DESCRIPTION
This crates does not need default ssl feature from hyper
Disable it allow to compile this crate with deps having
different openssl version from hyper 0.9

Cheers