### PR TITLE
Remove unused macro definition

### DIFF
--- a/src/server/field.rs
+++ b/src/server/field.rs
@@ -34,15 +34,6 @@ macro_rules! try_io(
     )
 );
 
-macro_rules! assert_log_ret_none (
-    ($expr, $else_:expr) => (
-        if !$expr {
-            $else_;
-            return None;
-        }
-    )
-);
-
 const EMPTY_STR_HEADER: StrHeader<'static> = StrHeader {
     name: "",
     val: "",


### PR DESCRIPTION
This removes an unused, erroneous macro definition.
The macro definition compiles today due to https://github.com/rust-lang/rust/issues/39404, which will be fixed in https://github.com/rust-lang/rust/pull/39419.
