### PR TITLE
0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "multipart"
 
-version = "0.9.0"
+version = "0.10.0-alpha.1"
 
 authors = ["Austin Bonander <austin.bonander@gmail.com>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ twoway = { version = "0.1", optional = true }
 
 # Optional Integrations
 hyper = { version = "0.9", optional = true, default-features = false }
-iron = { version = "0.5", optional = true }
+iron = { version = ">=0.4,<0.6", optional = true }
 
 # NOTE: use `nickel_` feature, as `hyper` feature is required.
 nickel = { optional = true, version = "0.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "multipart"
 
-version = "0.10.0-alpha.3"
+version = "0.10.0"
 
 authors = ["Austin Bonander <austin.bonander@gmail.com>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "multipart"
 
-version = "0.10.0-alpha.1"
+version = "0.10.0-alpha.2"
 
 authors = ["Austin Bonander <austin.bonander@gmail.com>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "multipart"
 
-version = "0.10.0-alpha.2"
+version = "0.10.0-alpha.3"
 
 authors = ["Austin Bonander <austin.bonander@gmail.com>"]
 

--- a/examples/iron.rs
+++ b/examples/iron.rs
@@ -3,7 +3,7 @@ extern crate iron;
 
 use std::fs::File;
 use std::io::Read;
-use multipart::server::{Multipart, Entries, SaveResult};
+use multipart::server::{Multipart, Entries, SaveResult, SavedFile};
 use iron::prelude::*;
 use iron::status;
 
@@ -17,13 +17,13 @@ fn process_request(request: &mut Request) -> IronResult<Response> {
     match Multipart::from_request(request) {
         Ok(mut multipart) => {
             // Fetching all data and processing it.
-            // save_all() reads the request fully, parsing all fields and saving all files
+            // save().temp() reads the request fully, parsing all fields and saving all files
             // in a new temporary directory under the OS temporary directory.
-            match multipart.save_all() {
+            match multipart.save().temp() {
                 SaveResult::Full(entries) => process_entries(entries),
-                SaveResult::Partial(entries, error) => {
-                    try!(process_entries(entries));
-                    Err(IronError::new(error, status::InternalServerError))
+                SaveResult::Partial(entries, reason) => {
+                    try!(process_entries(entries.keep_partial()));
+                    Err(IronError::new(reason.unwrap_err(), status::InternalServerError))
                 }
                 SaveResult::Error(error) => Err(IronError::new(error, status::InternalServerError)),
             }
@@ -38,29 +38,37 @@ fn process_request(request: &mut Request) -> IronResult<Response> {
 /// Returns an OK response or an error.
 fn process_entries(entries: Entries) -> IronResult<Response> {
     for (name, field) in entries.fields {
-        println!(r#"Field "{}": "{}""#, name, field);
+        println!("Field {:?}: {:?}", name, field);
     }
 
-    for (name, savedfile) in entries.files {
-        let filename = match savedfile.filename {
-            Some(s) => s,
-            None => "None".into(),
-        };
-        let mut file = match File::open(savedfile.path) {
-            Ok(file) => file,
-            Err(error) => {
-                return Err(IronError::new(error,
-                                          (status::InternalServerError,
-                                           "Server couldn't save file")))
-            }
-        };
-        let mut contents = String::new();
-        if let Err(error) = file.read_to_string(&mut contents) {
-            return Err(IronError::new(error, (status::BadRequest, "The file was not a text")));
+    for (name, files) in entries.files {
+        println!("Field {:?} has {} files:", name, files.len());
+
+        for file in files {
+            try!(print_file(&file));
         }
-
-        println!(r#"Field "{}" is file "{}":"#, name, filename);
-        println!("{}", contents);
     }
+
     Ok(Response::with((status::Ok, "Multipart data is processed")))
+}
+
+fn print_file(saved_file: &SavedFile) -> IronResult<()> {
+    let mut file = match File::open(&saved_file.path) {
+        Ok(file) => file,
+        Err(error) => {
+            return Err(IronError::new(error,
+                                      (status::InternalServerError,
+                                       "Server couldn't open saved file")))
+        }
+    };
+
+    let mut contents = String::new();
+    if let Err(error) = file.read_to_string(&mut contents) {
+        return Err(IronError::new(error, (status::BadRequest, "The file was not a text")));
+    }
+
+    println!("File {:?} ({:?}):", saved_file.filename, saved_file.content_type);
+    println!("{}", contents);
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@
 //! See the [`server::nickel`](server/nickel/index.html) module for more information. Enables the `hyper`
 //! feature.
 #![deny(missing_docs)]
-#![cfg_attr(feature = "nightly", feature(insert_str))]
 
 #[macro_use]
 extern crate log;
@@ -37,7 +36,9 @@ extern crate log;
 #[cfg(test)]
 extern crate env_logger;
 
+#[cfg_attr(test, macro_use)]
 extern crate mime;
+
 extern crate mime_guess;
 extern crate rand;
 extern crate tempdir;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! * `nickel_`: Integration with the [Nickel](http://nickel.rs) web application framework.
 //! See the [`server::nickel`](server/nickel/index.html) module for more information. Enables the `hyper`
 //! feature.
-#![warn(missing_docs)]
+#![deny(missing_docs)]
 #![cfg_attr(feature = "nightly", feature(insert_str))]
 
 #[macro_use]

--- a/src/local_test.rs
+++ b/src/local_test.rs
@@ -162,15 +162,15 @@ fn test_server(buf: HttpBuffer, mut fields: TestFields) {
                 assert!(
                     test_text.is_some(),
                     "Got text field that wasn't in original dataset: {:?} : {:?} ",
-                    field.name, text
+                    field.name, text.text
                 );
 
                 let test_text = test_text.unwrap();
 
                 assert!(
-                    text == test_text, 
+                    text.text == test_text,
                     "Unexpected data for field {:?}: Expected {:?}, got {:?}", 
-                    field.name, test_text, text
+                    field.name, test_text, text.text
                 );
 
             },
@@ -184,6 +184,7 @@ fn test_server(buf: HttpBuffer, mut fields: TestFields) {
                         field.name, String::from_utf8_lossy(&test_bytes), String::from_utf8_lossy(&bytes)
                 );
             },
+            _ => unimplemented!(),
         }
     }
 

--- a/src/local_test.rs
+++ b/src/local_test.rs
@@ -301,7 +301,7 @@ fn test_server(buf: HttpBuffer, fields: &mut TestFields) {
     let mut multipart = Multipart::from_request(server_buf)
         .unwrap_or_else(|_| panic!("Buffer should be multipart!"));
 
-    while let Some(mut field) = multipart.read_entry().unwrap() {
+    while let Some(mut field) = multipart.read_entry_mut().unwrap_opt() {
         fields.check_field(&mut field);
     }
 }

--- a/src/server/boundary.rs
+++ b/src/server/boundary.rs
@@ -132,8 +132,7 @@ impl<R> BoundaryReader<R> where R: Read {
 
         if log_enabled!(LogLevel::Trace) {
             trace!("Consumed up to self.search_idx, remaining buf: {:?}",
-                   String::from_utf8_lossy(self.source.get_buf())
-            );
+                   String::from_utf8_lossy(self.source.get_buf()));
         }
 
         let consume_amt = {

--- a/src/server/boundary.rs
+++ b/src/server/boundary.rs
@@ -18,8 +18,6 @@ use std::borrow::Borrow;
 use std::io;
 use std::io::prelude::*;
 
-use std::mem;
-
 /// A struct implementing `Read` and `BufRead` that will yield bytes until it sees a given sequence.
 #[derive(Debug)]
 pub struct BoundaryReader<R> {
@@ -165,19 +163,6 @@ impl<R> BoundaryReader<R> where R: Read {
         }
 
         Ok(self.at_end)
-    }
-
-    // Keeping this around to support nested boundaries later.
-    #[allow(unused)]
-    #[doc(hidden)]
-    pub fn swap_boundary<B: Into<Vec<u8>>>(&mut self, boundary: B) -> Vec<u8> {
-        let mut boundary = boundary.into();
-
-        if boundary.get(..2) != Some(b"--") {
-            safemem::prepend(b"--", &mut boundary);
-        }
-
-        mem::replace(&mut self.boundary, boundary)
     }
 }
 

--- a/src/server/field.rs
+++ b/src/server/field.rs
@@ -11,15 +11,14 @@ use super::httparse::{self, EMPTY_HEADER, Status};
 
 use self::ReadEntryResult::*;
 
-use super::save::{PartialReason, SaveBuilder, SavedFile};
+use super::save::{SaveBuilder, SavedFile};
 
 use mime::{TopLevel, Mime};
 
-use std::fs::{self, OpenOptions};
 use std::io::{self, Read, BufRead, Write};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::{env, str};
+use std::str;
 
 macro_rules! try_io(
     ($try:expr) => (

--- a/src/server/field.rs
+++ b/src/server/field.rs
@@ -108,10 +108,6 @@ impl FieldHeaders {
             cont_type: cont_type,
         })
     }
-
-    fn name(&self) -> &str {
-        &self.cont_disp.field_name
-    }
 }
 
 /// The `Content-Disposition` header.
@@ -233,16 +229,6 @@ pub enum MultipartData<M: ReadEntry> {
 }
 
 impl<M: ReadEntry> MultipartData<M> {
-    fn inner_mut(&mut self) -> &mut M {
-        use self::MultipartData::*;
-
-        match *self {
-            Text(ref mut text) => text.inner_mut(),
-            File(ref mut file) => file.inner_mut(),
-            Nested(ref mut nested) => nested.inner_mut(),
-        }
-    }
-
     /// Borrow this payload as a text field, if possible.
     pub fn as_text(&self) -> Option<&str> {
         match *self {

--- a/src/server/field.rs
+++ b/src/server/field.rs
@@ -534,6 +534,7 @@ fn find_header<'a, 'b>(headers: &'a [StrHeader<'b>], name: &str) -> Option<&'a S
 
 /// Common trait for `Multipart` and `&mut Multipart`
 pub trait ReadEntry: PrivReadEntry + Sized {
+    /// Attempt to read the next entry in the multipart stream.
     fn read_entry(mut self) -> ReadEntryResult<Self> {
         if try_read_entry!(self; self.consume_boundary()) {
             return End(self);
@@ -623,7 +624,8 @@ impl<'a, M: ReadEntry> PrivReadEntry for &'a mut M {
     }
 }
 
-/// Result type returned by `Multipart::into_entry()` and `MultipartField::next_entry()`.
+/// Ternary result type returned by `ReadEntry::next_entry()`,
+/// `Multipart::into_entry()` and `MultipartField::next_entry()`.
 pub enum ReadEntryResult<M: ReadEntry, Entry = MultipartField<M>> {
     /// The next entry was found.
     Entry(Entry),

--- a/src/server/field.rs
+++ b/src/server/field.rs
@@ -375,7 +375,7 @@ impl<M> MultipartFile<M> {
     /// permissions, but you should still not use user input directly as filesystem paths.
     /// If it is truly necessary, you should sanitize filenames such that they cannot be
     /// misinterpreted by the OS. Such functionality is outside the scope of this crate.
-    #[deprecated = "`filename` field is now public"]
+    #[deprecated(since = "0.10.0", note = "`filename` field is now public")]
     pub fn filename(&self) -> Option<&str> {
         self.filename.as_ref().map(String::as_ref)
     }
@@ -390,7 +390,7 @@ impl<M> MultipartFile<M> {
     /// Some variants wrap arbitrary strings which could be abused by a malicious user if your
     /// application performs any non-idempotent operations based on their value, such as
     /// starting another program or querying/updating a database (web-search "SQL injection").
-    #[deprecated = "`content_type` field is now public"]
+    #[deprecated(since = "0.10.0", note = "`content_type` field is now public")]
     pub fn content_type(&self) -> &Mime {
         &self.content_type
     }
@@ -421,7 +421,7 @@ impl<M> MultipartFile<M> where M: ReadEntry {
     /// If successful, returns the number of bytes written.
     ///
     /// Retries when `io::Error::kind() == io::ErrorKind::Interrupted`.
-    #[deprecated = "use `.save().write_to()` instead"]
+    #[deprecated(since = "0.10.0", note = "use `.save().write_to()` instead")]
     pub fn save_to<W: Write>(&mut self, out: W) -> io::Result<u64> {
         self.save().write_to(out).into_result_strict()
     }
@@ -432,7 +432,7 @@ impl<M> MultipartFile<M> where M: ReadEntry {
     /// If successful, returns the number of bytes written.
     ///
     /// Retries when `io::Error::kind() == io::ErrorKind::Interrupted`.
-    #[deprecated = "use `.save().limit(limit).write_to(out)` instead"]
+    #[deprecated(since = "0.10.0", note = "use `.save().size_limit(limit).write_to(out)` instead")]
     pub fn save_to_limited<W: Write>(&mut self, out: W, limit: u64) -> io::Result<u64> {
         self.save().size_limit(limit).write_to(out).into_result_strict()
     }
@@ -442,7 +442,7 @@ impl<M> MultipartFile<M> where M: ReadEntry {
     /// Returns the saved file info on success, or any errors otherwise.
     ///
     /// Retries when `io::Error::kind() == io::ErrorKind::Interrupted`.
-    #[deprecated = "use `.save().with_path(path)` instead"]
+    #[deprecated(since = "0.10.0", note = "use `.save().with_path(path)` instead")]
     pub fn save_as<P: Into<PathBuf>>(&mut self, path: P) -> io::Result<SavedFile> {
         self.save().with_path(path).into_result_strict()
     }
@@ -455,7 +455,7 @@ impl<M> MultipartFile<M> where M: ReadEntry {
     /// Returns the saved file's info on success, or any errors otherwise.
     ///
     /// Retries when `io::Error::kind() == io::ErrorKind::Interrupted`.
-    #[deprecated = "use `.save().with_dir(dir)` instead"]
+    #[deprecated(since = "0.10.0", note = "use `.save().with_dir(dir)` instead")]
     pub fn save_in<P: AsRef<Path>>(&mut self, dir: P) -> io::Result<SavedFile> {
         self.save().with_dir(dir.as_ref()).into_result_strict()
     }
@@ -467,7 +467,7 @@ impl<M> MultipartFile<M> where M: ReadEntry {
     /// Returns the saved file's info on success, or any errors otherwise.
     ///
     /// Retries when `io::Error::kind() == io::ErrorKind::Interrupted`.
-    #[deprecated = "use `.save().limit(limit).with_path(path)` instead"]
+    #[deprecated(since = "0.10.0", note = "use `.save().size_limit(limit).with_path(path)` instead")]
     pub fn save_as_limited<P: Into<PathBuf>>(&mut self, path: P, limit: u64) -> io::Result<SavedFile> {
         self.save().size_limit(limit).with_path(path).into_result_strict()
     }
@@ -482,7 +482,7 @@ impl<M> MultipartFile<M> where M: ReadEntry {
     /// Returns the saved file's info on success, or any errors otherwise.
     ///
     /// Retries when `io::Error::kind() == io::ErrorKind::Interrupted`.
-    #[deprecated = "use `.save().limit(limit).with_dir(dir)` instead"]
+    #[deprecated(since = "0.10.0", note = "use `.save().size_limit(limit).with_dir(dir)` instead")]
     pub fn save_in_limited<P: AsRef<Path>>(&mut self, dir: P, limit: u64) -> io::Result<SavedFile> {
         self.save().size_limit(limit).with_dir(dir).into_result_strict()
     }

--- a/src/server/field.rs
+++ b/src/server/field.rs
@@ -584,6 +584,11 @@ pub trait ReadEntry: PrivReadEntry + Sized {
             }
         )
     }
+
+    /// Equivalent to `read_entry()` but takes `&mut self`
+    fn read_entry_mut(&mut self) -> ReadEntryResult<&mut Self> {
+        ReadEntry::read_entry(self)
+    }
 }
 
 impl<T> ReadEntry for T where T: PrivReadEntry {}

--- a/src/server/field.rs
+++ b/src/server/field.rs
@@ -870,6 +870,11 @@ pub enum ReadEntryResult<M: ReadEntry, Entry = MultipartField<M>> {
 }
 
 impl<M: ReadEntry, Entry> ReadEntryResult<M, Entry> {
+    /// Convert `self` into `Result<Option<Entry>>` as follows:
+    ///
+    /// * `Entry(entry) -> Ok(Some(entry))`
+    /// * `End(_) -> Ok(None)`
+    /// * `Error(_, err) -> Err(err)`
     pub fn into_result(self) -> io::Result<Option<Entry>> {
         match self {
             ReadEntryResult::Entry(entry) => Ok(Some(entry)),
@@ -878,15 +883,21 @@ impl<M: ReadEntry, Entry> ReadEntryResult<M, Entry> {
         }
     }
 
+    /// Attempt to unwrap `Entry`, panicking if this is `End` or `Error`.
     pub fn unwrap(self) -> Entry {
         self.expect_alt("`ReadEntryResult::unwrap()` called on `End` value",
                         "`ReadEntryResult::unwrap()` called on `Error` value: {:?}")
     }
 
+    /// Attempt to unwrap `Entry`, panicking if this is `End` or `Error`
+    /// with the given message. Adds the error's message in the `Error` case.
     pub fn expect(self, msg: &str) -> Entry {
         self.expect_alt(msg, msg)
     }
 
+    /// Attempt to unwrap `Entry`, panicking if this is `End` or `Error`.
+    /// If this is `End`, panics with `end_msg`; if `Error`, panics with `err_msg`
+    /// as well as the error's message.
     pub fn expect_alt(self, end_msg: &str, err_msg: &str) -> Entry {
         match self {
             Entry(entry) => entry,
@@ -895,10 +906,13 @@ impl<M: ReadEntry, Entry> ReadEntryResult<M, Entry> {
         }
     }
 
+    /// Attempt to unwrap as `Option<Entry>`, panicking in the `Error` case.
     pub fn unwrap_opt(self) -> Option<Entry> {
         self.expect_opt("`ReadEntryResult::unwrap_opt()` called on `Error` value")
     }
 
+    /// Attempt to unwrap as `Option<Entry>`, panicking in the `Error` case
+    /// with the given message as well as the error's message.
     pub fn expect_opt(self, msg: &str) -> Option<Entry> {
         match self {
             Entry(entry) => Some(entry),

--- a/src/server/field.rs
+++ b/src/server/field.rs
@@ -305,8 +305,9 @@ impl<M> Into<String> for MultipartText<M> {
 }
 
 impl<M> MultipartText<M> {
-    fn take_inner(&mut self) -> M {
-        self.inner.take().expect("MultipartText::inner taken!")
+    #[doc(hidden)]
+    pub fn take_inner(&mut self) -> M {
+        self.inner.take().expect("MultipartText::inner already taken!")
     }
 
     fn into_inner(self) -> M {
@@ -400,8 +401,9 @@ impl<M> MultipartFile<M> {
         self.inner.as_mut().expect("MultipartFile::inner taken!")
     }
 
-    fn take_inner(&mut self) -> M {
-        self.inner.take().expect("MultipartFile::inner taken!")
+    #[doc(hidden)]
+    pub fn take_inner(&mut self) -> M {
+        self.inner.take().expect("MultipartFile::inner already taken!")
     }
 
     fn into_inner(self) -> M {
@@ -433,7 +435,7 @@ impl<M> MultipartFile<M> where M: ReadEntry {
     /// Retries when `io::Error::kind() == io::ErrorKind::Interrupted`.
     #[deprecated = "use `.save().limit(limit).write_to(out)` instead"]
     pub fn save_to_limited<W: Write>(&mut self, out: W, limit: u64) -> io::Result<u64> {
-        self.save().limit(limit).write_to(out).into_result_strict()
+        self.save().size_limit(limit).write_to(out).into_result_strict()
     }
 
     /// Save this file to `path`.
@@ -468,7 +470,7 @@ impl<M> MultipartFile<M> where M: ReadEntry {
     /// Retries when `io::Error::kind() == io::ErrorKind::Interrupted`.
     #[deprecated = "use `.save().limit(limit).with_path(path)` instead"]
     pub fn save_as_limited<P: Into<PathBuf>>(&mut self, path: P, limit: u64) -> io::Result<SavedFile> {
-        self.save().limit(limit).with_path(path).into_result_strict()
+        self.save().size_limit(limit).with_path(path).into_result_strict()
     }
 
     /// Save this file in the directory pointed at by `dir`,
@@ -483,7 +485,7 @@ impl<M> MultipartFile<M> where M: ReadEntry {
     /// Retries when `io::Error::kind() == io::ErrorKind::Interrupted`.
     #[deprecated = "use `.save().limit(limit).with_dir(dir)` instead"]
     pub fn save_in_limited<P: AsRef<Path>>(&mut self, dir: P, limit: u64) -> io::Result<SavedFile> {
-        self.save().limit(limit).with_dir(dir).into_result_strict()
+        self.save().size_limit(limit).with_dir(dir).into_result_strict()
     }
 }
 

--- a/src/server/iron.rs
+++ b/src/server/iron.rs
@@ -171,8 +171,9 @@ impl Intercept {
                     file_count += 1;
                 },
                 MultipartData::Text(text) => {
-                    entries.fields.insert(field.name, text.into());
+                    entries.fields.insert(field.name, text.text);
                 },
+                MultipartData::_Swapping => unreachable!("MultipartData::_Swapping was left in-place somehow"),
             }
         }
 

--- a/src/server/iron.rs
+++ b/src/server/iron.rs
@@ -12,7 +12,8 @@ use iron::{BeforeMiddleware, IronError, IronResult};
 use std::path::PathBuf;
 use std::{error, fmt};
 
-use super::{Entries, HttpRequest, Multipart, MultipartData};
+use super::{HttpRequest, Multipart, MultipartData};
+use super::save::Entries;
 
 impl<'r, 'a, 'b> HttpRequest for &'r mut IronRequest<'a, 'b> {
     type Body = &'r mut IronBody<'a, 'b>;

--- a/src/server/iron.rs
+++ b/src/server/iron.rs
@@ -150,7 +150,7 @@ impl Intercept {
                     }
 
                     let file = try_iron!(
-                        file.save_in_limited(&entries.dir, self.file_size_limit);
+                        file.save().limit(self.file_size_limit).with_dir(&entries.dir);
                         "Error reading field: \"{}\" (filename: \"{}\")",
                         field.name,
                         file.filename().unwrap_or("(none)")

--- a/src/server/iron.rs
+++ b/src/server/iron.rs
@@ -12,8 +12,8 @@ use iron::{BeforeMiddleware, IronError, IronResult};
 use std::path::PathBuf;
 use std::{error, fmt, io};
 
-use super::{HttpRequest, Multipart, MultipartData};
-use super::save::{Entries, PartialReason, SaveBuilder, TempDir};
+use super::{HttpRequest, Multipart};
+use super::save::{Entries, PartialReason, TempDir};
 use super::save::SaveResult::*;
 
 impl<'r, 'a, 'b> HttpRequest for &'r mut IronRequest<'a, 'b> {
@@ -119,7 +119,7 @@ impl Intercept {
     }
 
     fn read_request(&self, req: &mut IronRequest) -> IronResult<Option<Entries>> {
-        let mut multipart = match Multipart::from_request(req) {
+        let multipart = match Multipart::from_request(req) {
             Ok(multipart) => multipart,
             Err(_) => return Ok(None),
         };
@@ -226,17 +226,6 @@ pub enum LimitBehavior {
     Continue,
 }
 
-impl LimitBehavior {
-    fn throw_error(self) -> bool {
-        use self::LimitBehavior::*;
-
-        match self {
-            ThrowError => true,
-            Continue => false,
-        }
-    }
-}
-
 /// An error returned from `Intercept` when the size limit
 /// for an individual file is exceeded.
 #[derive(Debug)]
@@ -245,15 +234,6 @@ pub struct FileSizeLimitError {
     pub field: String,
     /// The filename of the oversize file, if it was provided.
     pub filename: Option<String>,
-}
-
-impl FileSizeLimitError {
-    fn new(field: String, filename: Option<String>) -> Self {
-        FileSizeLimitError {
-            field: field,
-            filename: filename
-        }
-    }
 }
 
 impl error::Error for FileSizeLimitError {

--- a/src/server/iron.rs
+++ b/src/server/iron.rs
@@ -173,7 +173,7 @@ impl Intercept {
                 MultipartData::Text(text) => {
                     entries.fields.insert(field.name, text.text);
                 },
-                MultipartData::_Swapping => unreachable!("MultipartData::_Swapping was left in-place somehow"),
+                MultipartData::Nested(nested) => unimplemented!(),
             }
         }
 

--- a/src/server/iron.rs
+++ b/src/server/iron.rs
@@ -153,7 +153,7 @@ impl Intercept {
                         file.save().limit(self.file_size_limit).with_dir(&entries.dir);
                         "Error reading field: \"{}\" (filename: \"{}\")",
                         field.name,
-                        file.filename().unwrap_or("(none)")
+                        file.filename.as_ref().map_or("(none)", |f| f)
                     );
 
                     if file.size == self.file_size_limit {
@@ -173,7 +173,6 @@ impl Intercept {
                 MultipartData::Text(text) => {
                     entries.fields.insert(field.name, text.text);
                 },
-                MultipartData::Nested(nested) => unimplemented!(),
             }
         }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -118,7 +118,7 @@ impl<R: Read> Multipart<R> {
     /// If the previously returned entry had contents of type `MultipartField::File`,
     /// calling this again will discard any unread contents of that entry.
     pub fn read_entry(&mut self) -> io::Result<Option<MultipartField<&mut Self>>> {
-        PrivReadEntry::read_entry(self).into_result()
+        ReadEntry::read_entry(self).into_result()
     }
 
     /// Read the next entry from this multipart request, returning a struct with the field's name and
@@ -143,7 +143,7 @@ impl<R: Read> Multipart<R> {
         }
     }
 
-    pub fn save(&mut self) -> SaveBuilder<Self> {
+    pub fn save(&mut self) -> SaveBuilder<&mut Self> {
         SaveBuilder::new(self)
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -31,7 +31,7 @@ pub use self::field::{MultipartField, MultipartFile, MultipartData, ReadEntry, R
 
 use self::save::SaveBuilder;
 
-pub use self::save::{Entries, SaveResult};
+pub use self::save::{Entries, SaveResult, SavedFile};
 
 use self::save::EntriesSaveResult;
 
@@ -116,7 +116,7 @@ impl<R: Read> Multipart<R> {
     /// If the previously returned entry had contents of type `MultipartField::File`,
     /// calling this again will discard any unread contents of that entry.
     pub fn read_entry(&mut self) -> io::Result<Option<MultipartField<&mut Self>>> {
-        ReadEntry::read_entry(self).into_result()
+        self.read_entry_mut().into_result()
     }
 
     /// Read the next entry from this multipart request, returning a struct with the field's name and

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -218,11 +218,7 @@ impl<B: Read> Multipart<B> {
         while let Some(field) = try!(self.read_entry()) {
             match field.data {
                 MultipartData::File(mut file) => {
-                    let file = if let Some(limit) = limit {
-                        try!(file.save_in_limited(&entries.dir, limit))
-                    } else {
-                        try!(file.save_in(&entries.dir))
-                    };
+                    let file = try!(file.save().limit(limit).with_dir(&entries.dir));
 
                     entries.files.insert(field.name, file);
                 },

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -35,6 +35,8 @@ use self::save::SaveBuilder;
 
 pub use self::save::{Entries, SaveResult};
 
+use self::save::EntriesSaveResult;
+
 macro_rules! try_opt (
     ($expr:expr) => (
         match $expr {
@@ -151,7 +153,7 @@ impl<B: Read> Multipart<B> {
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
     #[deprecated = "use `.save().temp()` instead"]
-    pub fn save_all(&mut self) -> SaveResult {
+    pub fn save_all(&mut self) -> EntriesSaveResult {
         self.save().temp()
     }
 
@@ -161,7 +163,7 @@ impl<B: Read> Multipart<B> {
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
     #[deprecated = "use `.save().with_temp_dir()` instead"]
-    pub fn save_all_under<P: AsRef<Path>>(&mut self, dir: P) -> SaveResult {
+    pub fn save_all_under<P: AsRef<Path>>(&mut self, dir: P) -> EntriesSaveResult {
         match TempDir::new_in(dir, "multipart") {
             Ok(temp_dir) => self.save().with_temp_dir(temp_dir),
             Err(err) => return SaveResult::Error(err),
@@ -176,7 +178,7 @@ impl<B: Read> Multipart<B> {
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
     #[deprecated = "use `.save().limit(limit)` instead"]
-    pub fn save_all_limited(&mut self, limit: u64) -> SaveResult {
+    pub fn save_all_limited(&mut self, limit: u64) -> EntriesSaveResult {
         self.save().limit(limit).temp()
     }
 
@@ -188,7 +190,7 @@ impl<B: Read> Multipart<B> {
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
     #[deprecated = "use `.save().limit(limit).with_temp_dir()` instead"]
-    pub fn save_all_under_limited<P: AsRef<Path>>(&mut self, dir: P, limit: u64) -> SaveResult {
+    pub fn save_all_under_limited<P: AsRef<Path>>(&mut self, dir: P, limit: u64) -> EntriesSaveResult {
         match TempDir::new_in(dir, "multipart") {
             Ok(temp_dir) => self.save().limit(limit).with_temp_dir(temp_dir),
             Err(err) => return SaveResult::Error(err),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -84,8 +84,8 @@ pub mod save;
 /// The server-side implementation of `multipart/form-data` requests.
 ///
 /// Implements `Borrow<R>` to allow access to the request body, if desired.
-pub struct Multipart<B> {
-    reader: BoundaryReader<B>,
+pub struct Multipart<R> {
+    reader: BoundaryReader<R>,
 }
 
 impl Multipart<()> {
@@ -103,9 +103,9 @@ impl Multipart<()> {
     }   
 }
 
-impl<B: Read> Multipart<B> {
+impl<R: Read> Multipart<R> {
     /// Construct a new `Multipart` with the given body reader and boundary.
-    pub fn with_body<Bnd: Into<String>>(body: B, boundary: Bnd) -> Self {
+    pub fn with_body<Bnd: Into<String>>(body: R, boundary: Bnd) -> Self {
         Multipart { 
             reader: BoundaryReader::from_reader(body, boundary.into()),
         }
@@ -153,7 +153,7 @@ impl<B: Read> Multipart<B> {
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
     #[deprecated = "use `.save().temp()` instead"]
-    pub fn save_all(&mut self) -> EntriesSaveResult {
+    pub fn save_all(&mut self) -> EntriesSaveResult<R> {
         self.save().temp()
     }
 
@@ -163,7 +163,7 @@ impl<B: Read> Multipart<B> {
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
     #[deprecated = "use `.save().with_temp_dir()` instead"]
-    pub fn save_all_under<P: AsRef<Path>>(&mut self, dir: P) -> EntriesSaveResult {
+    pub fn save_all_under<P: AsRef<Path>>(&mut self, dir: P) -> EntriesSaveResult<R> {
         match TempDir::new_in(dir, "multipart") {
             Ok(temp_dir) => self.save().with_temp_dir(temp_dir),
             Err(err) => return SaveResult::Error(err),
@@ -178,7 +178,7 @@ impl<B: Read> Multipart<B> {
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
     #[deprecated = "use `.save().limit(limit)` instead"]
-    pub fn save_all_limited(&mut self, limit: u64) -> EntriesSaveResult {
+    pub fn save_all_limited(&mut self, limit: u64) -> EntriesSaveResult<R> {
         self.save().limit(limit).temp()
     }
 
@@ -190,7 +190,7 @@ impl<B: Read> Multipart<B> {
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
     #[deprecated = "use `.save().limit(limit).with_temp_dir()` instead"]
-    pub fn save_all_under_limited<P: AsRef<Path>>(&mut self, dir: P, limit: u64) -> EntriesSaveResult {
+    pub fn save_all_under_limited<P: AsRef<Path>>(&mut self, dir: P, limit: u64) -> EntriesSaveResult<R> {
         match TempDir::new_in(dir, "multipart") {
             Ok(temp_dir) => self.save().limit(limit).with_temp_dir(temp_dir),
             Err(err) => return SaveResult::Error(err),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -142,6 +142,8 @@ impl<R: Read> Multipart<R> {
     }
 
     /// Get a builder type for saving the files in this request to the filesystem.
+    ///
+    /// See [`SaveBuilder`](save/struct.SaveBuilder.html) for more information.
     pub fn save(&mut self) -> SaveBuilder<&mut Self> {
         SaveBuilder::new(self)
     }
@@ -150,8 +152,8 @@ impl<R: Read> Multipart<R> {
     /// directory under the OS temporary directory. 
     ///
     /// If there is an error in reading the request, returns the partial result along with the
-    /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
-    #[deprecated = "use `.save().temp()` instead"]
+    /// error. See [`SaveResult`](save/enum.SaveResult.html) for more information.
+    #[deprecated(since = "0.10.0", note = "use `.save().temp()` instead")]
     pub fn save_all(&mut self) -> EntriesSaveResult<&mut Self> {
         self.save().temp()
     }
@@ -160,8 +162,8 @@ impl<R: Read> Multipart<R> {
     /// directory under `dir`. 
     ///
     /// If there is an error in reading the request, returns the partial result along with the
-    /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
-    #[deprecated = "use `.save().with_temp_dir()` instead"]
+    /// error. See [`SaveResult`](save/enum.SaveResult.html) for more information.
+    #[deprecated(since = "0.10.0", note = "use `.save().with_temp_dir()` instead")]
     pub fn save_all_under<P: AsRef<Path>>(&mut self, dir: P) -> EntriesSaveResult<&mut Self> {
         match TempDir::new_in(dir, "multipart") {
             Ok(temp_dir) => self.save().with_temp_dir(temp_dir),
@@ -175,8 +177,8 @@ impl<R: Read> Multipart<R> {
     /// Files larger than `limit` will be truncated to `limit`.
     ///
     /// If there is an error in reading the request, returns the partial result along with the
-    /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
-    #[deprecated = "use `.save().limit(limit)` instead"]
+    /// error. See [`SaveResult`](save/enum.SaveResult.html) for more information.
+    #[deprecated(since = "0.10.0", note = "use `.save().size_limit(limit)` instead")]
     pub fn save_all_limited(&mut self, limit: u64) -> EntriesSaveResult<&mut Self> {
         self.save().size_limit(limit).temp()
     }
@@ -187,8 +189,8 @@ impl<R: Read> Multipart<R> {
     /// Files larger than `limit` will be truncated to `limit`.
     ///
     /// If there is an error in reading the request, returns the partial result along with the
-    /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
-    #[deprecated = "use `.save().limit(limit).with_temp_dir()` instead"]
+    /// error. See [`SaveResult`](save/enum.SaveResult.html) for more information.
+    #[deprecated(since = "0.10.0", note = "use `.save().size_limit(limit).with_temp_dir()` instead")]
     pub fn save_all_under_limited<P: AsRef<Path>>(&mut self, dir: P, limit: u64) -> EntriesSaveResult<&mut Self> {
         match TempDir::new_in(dir, "multipart") {
             Ok(temp_dir) => self.save().size_limit(limit).with_temp_dir(temp_dir),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -16,8 +16,6 @@ extern crate httparse;
 extern crate safemem;
 extern crate twoway;
 
-use tempdir::TempDir;
-
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::fs;
@@ -25,12 +23,17 @@ use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::{io, mem};
 
+use tempdir::TempDir;
+
 use self::boundary::BoundaryReader;
 
 use self::field::PrivReadEntry;
 
-pub use self::field::{MultipartField, MultipartFile, MultipartData, ReadEntry, ReadEntryResult,
-                      SaveBuilder, SavedFile};
+pub use self::field::{MultipartField, MultipartFile, MultipartData, ReadEntry, ReadEntryResult};
+
+use self::save::SaveBuilder;
+
+pub use self::save::{Entries, SaveResult};
 
 macro_rules! try_opt (
     ($expr:expr) => (
@@ -73,6 +76,8 @@ pub mod nickel;
 
 #[cfg(feature = "tiny_http")]
 pub mod tiny_http;
+
+pub mod save;
 
 /// The server-side implementation of `multipart/form-data` requests.
 ///
@@ -136,21 +141,18 @@ impl<B: Read> Multipart<B> {
         }
     }
 
+    pub fn save(&mut self) -> SaveBuilder<Self> {
+        SaveBuilder::new(self)
+    }
+
     /// Read the request fully, parsing all fields and saving all files in a new temporary
     /// directory under the OS temporary directory. 
     ///
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
+    #[deprecated = "use `.save().temp()` instead"]
     pub fn save_all(&mut self) -> SaveResult {
-        let mut entries = match Entries::new_tempdir() {
-            Ok(entries) => entries,
-            Err(err) => return SaveResult::Error(err),
-        };
- 
-        match self.read_to_entries(&mut entries, None) {
-            Ok(()) => SaveResult::Full(entries),
-            Err(err) => SaveResult::Partial(entries, err),
-        }
+        self.save().temp()
     }
 
     /// Read the request fully, parsing all fields and saving all files in a new temporary
@@ -158,15 +160,11 @@ impl<B: Read> Multipart<B> {
     ///
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
+    #[deprecated = "use `.save().with_temp_dir()` instead"]
     pub fn save_all_under<P: AsRef<Path>>(&mut self, dir: P) -> SaveResult {
-        let mut entries = match Entries::new_tempdir_in(dir) {
-            Ok(entries) => entries,
+        match TempDir::new_in(dir, "multipart") {
+            Ok(temp_dir) => self.save().with_temp_dir(temp_dir),
             Err(err) => return SaveResult::Error(err),
-        };
-
-        match self.read_to_entries(&mut entries, None) {
-            Ok(()) => SaveResult::Full(entries),
-            Err(err) => SaveResult::Partial(entries, err),
         }
     }
 
@@ -177,16 +175,9 @@ impl<B: Read> Multipart<B> {
     ///
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
+    #[deprecated = "use `.save().limit(limit)` instead"]
     pub fn save_all_limited(&mut self, limit: u64) -> SaveResult {
-        let mut entries = match Entries::new_tempdir() {
-            Ok(entries) => entries,
-            Err(err) => return SaveResult::Error(err),
-        };
-
-        match self.read_to_entries(&mut entries, Some(limit)) {
-            Ok(()) => SaveResult::Full(entries),
-            Err(err) => SaveResult::Partial(entries, err),
-        }
+        self.save().limit(limit).temp()
     }
 
     /// Read the request fully, parsing all fields and saving all files in a new temporary
@@ -196,33 +187,12 @@ impl<B: Read> Multipart<B> {
     ///
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
+    #[deprecated = "use `.save().limit(limit).with_temp_dir()` instead"]
     pub fn save_all_under_limited<P: AsRef<Path>>(&mut self, dir: P, limit: u64) -> SaveResult {
-        let mut entries = match Entries::new_tempdir_in(dir) {
-            Ok(entries) => entries,
+        match TempDir::new_in(dir, "multipart") {
+            Ok(temp_dir) => self.save().limit(limit).with_temp_dir(temp_dir),
             Err(err) => return SaveResult::Error(err),
-        };
-
-        match self.read_to_entries(&mut entries, Some(limit)) {
-            Ok(()) => SaveResult::Full(entries),
-            Err(err) => SaveResult::Partial(entries, err),
         }
-    }
-
-    fn read_to_entries(&mut self, entries: &mut Entries, limit: Option<u64>) -> io::Result<()> {
-        while let Some(field) = try!(self.read_entry()) {
-            match field.data {
-                MultipartData::File(mut file) => {
-                    let file = try!(file.save().limit(limit).with_dir(&entries.dir));
-
-                    entries.files.insert(field.name, file);
-                },
-                MultipartData::Text(text) => {
-                    entries.fields.insert(field.name, text.text);
-                },
-            }
-        }
-
-        Ok(())
     }
 }
 
@@ -247,53 +217,6 @@ impl<R: Read> PrivReadEntry for Multipart<R> {
     }
 }
 
-/// The result of [`Multipart::save_all()`](struct.Multipart.html#method.save_all).
-#[derive(Debug)]
-pub enum SaveResult {
-    /// The operation was a total success. Contained are all entries of the request.
-    Full(Entries),
-    /// The operation errored partway through. Contained are the entries gathered thus far,
-    /// as well as the error that ended the process.
-    Partial(Entries, io::Error),
-    /// The `TempDir` for `Entries` could not be constructed. Contained is the error detailing the
-    /// problem.
-    Error(io::Error),
-}
-
-impl SaveResult {
-    /// Take the `Entries` from `self`, if applicable, and discarding
-    /// the error, if any.
-    pub fn to_entries(self) -> Option<Entries> {
-        use self::SaveResult::*;
-
-        match self {
-            Full(entries) | Partial(entries, _) => Some(entries),
-            Error(_) => None,
-        }
-    }
-
-    /// Decompose `self` to `(Option<Entries>, Option<io::Error>)`
-    pub fn to_opt(self) -> (Option<Entries>, Option<io::Error>) {
-        use self::SaveResult::*;
-
-        match self {
-            Full(entries) => (Some(entries), None),
-            Partial(entries, error) => (Some(entries), Some(error)),
-            Error(error) => (None, Some(error)),
-        }
-    }
-
-    /// Map `self` to an `io::Result`, discarding the error in the `Partial` case.
-    pub fn to_result(self) -> io::Result<Entries> {
-        use self::SaveResult::*;
-
-        match self {
-            Full(entries) | Partial(entries, _) => Ok(entries),
-            Error(error) => Err(error),
-        }
-    }
-}
-
 /// A server-side HTTP request that may or may not be multipart.
 ///
 /// May be implemented by mutable references if providing the request or body by-value is
@@ -310,114 +233,4 @@ pub trait HttpRequest {
 
     /// Return the request body for reading.
     fn body(self) -> Self::Body;
-}
-
-/// A result of `Multipart::save_all()`.
-#[derive(Debug)]
-pub struct Entries {
-    /// The text fields of the multipart request, mapped by field name -> value.
-    pub fields: HashMap<String, String>,
-    /// A map of file field names to their contents saved on the filesystem.
-    pub files: HashMap<String, SavedFile>,
-    /// The directory the files in this request were saved under; may be temporary or permanent.
-    pub dir: SaveDir,
-}
-
-impl Entries {
-    fn new_tempdir_in<P: AsRef<Path>>(path: P) -> io::Result<Self> {
-        TempDir::new_in(path, "multipart").map(Self::with_tempdir)
-    }
-
-    fn new_tempdir() -> io::Result<Self> {
-        TempDir::new("multipart").map(Self::with_tempdir)
-    }
-
-    fn with_tempdir(tempdir: TempDir) -> Entries {
-        Entries {
-            fields: HashMap::new(),
-            files: HashMap::new(),
-            dir: SaveDir::Temp(tempdir),
-        }
-    }
-}
-
-/// The save directory for `Entries`. May be temporary (delete-on-drop) or permanent.
-#[derive(Debug)]
-pub enum SaveDir {
-    /// This directory is temporary and will be deleted, along with its contents, when this wrapper
-    /// is dropped.
-    Temp(TempDir),
-    /// This directory is permanent and will be left on the filesystem when this wrapper is dropped.
-    Perm(PathBuf),
-}
-
-impl SaveDir {
-    /// Get the path of this directory, either temporary or permanent.
-    pub fn as_path(&self) -> &Path {
-        use self::SaveDir::*;
-        match *self {
-            Temp(ref tempdir) => tempdir.path(),
-            Perm(ref pathbuf) => &*pathbuf,
-        }
-    }
-
-    /// Returns `true` if this is a temporary directory which will be deleted on-drop.
-    pub fn is_temporary(&self) -> bool {
-        use self::SaveDir::*;
-        match *self {
-            Temp(_) => true,
-            Perm(_) => false,
-        }
-    }
-
-    /// Unwrap the `PathBuf` from `self`; if this is a temporary directory,
-    /// it will be converted to a permanent one.
-    pub fn into_path(self) -> PathBuf {
-        use self::SaveDir::*;
-
-        match self {
-            Temp(tempdir) => tempdir.into_path(),
-            Perm(pathbuf) => pathbuf,
-        }
-    }
-
-    /// If this `SaveDir` is temporary, convert it to permanent.
-    /// This is a no-op if it already is permanent.
-    ///
-    /// ###Warning: Potential Data Loss
-    /// Even though this will prevent deletion on-drop, the temporary folder on most OSes
-    /// (where this directory is created by default) can be automatically cleared by the OS at any
-    /// time, usually on reboot or when free space is low.
-    ///
-    /// It is recommended that you relocate the files from a request which you want to keep to a 
-    /// permanent folder on the filesystem.
-    pub fn keep(&mut self) {
-        use self::SaveDir::*;
-        *self = match mem::replace(self, Perm(PathBuf::new())) {
-            Temp(tempdir) => Perm(tempdir.into_path()),
-            old_self => old_self,
-        };
-    }
-
-    /// Delete this directory and its contents, regardless of its permanence.
-    ///
-    /// ###Warning: Potential Data Loss
-    /// This is very likely irreversible, depending on the OS implementation.
-    ///
-    /// Files deleted programmatically are deleted directly from disk, as compared to most file
-    /// manager applications which use a staging area from which deleted files can be safely
-    /// recovered (i.e. Windows' Recycle Bin, OS X's Trash Can, etc.).
-    pub fn delete(self) -> io::Result<()> {
-        use self::SaveDir::*;
-        match self {
-            Temp(tempdir) => tempdir.close(),
-            Perm(pathbuf) => fs::remove_dir_all(&pathbuf),
-        }
-    }
-}
-
-impl AsRef<Path> for SaveDir {
-    fn as_ref(&self) -> &Path {
-        self.as_path()
-    }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -219,7 +219,6 @@ impl<B: Read> Multipart<B> {
                 MultipartData::Text(text) => {
                     entries.fields.insert(field.name, text.text);
                 },
-                MultipartData::Nested(_) => unimplemented!(),
             }
         }
 
@@ -238,10 +237,6 @@ impl<R: Read> PrivReadEntry for Multipart<R> {
 
     fn source(&mut self) -> &mut BoundaryReader<R> {
         &mut self.reader
-    }
-
-    fn swap_boundary<B: Into<Vec<u8>>>(&mut self, boundary: B) -> Vec<u8> {
-        self.reader.swap_boundary(boundary)
     }
 
     /// Consume the next boundary.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -153,7 +153,7 @@ impl<R: Read> Multipart<R> {
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
     #[deprecated = "use `.save().temp()` instead"]
-    pub fn save_all(&mut self) -> EntriesSaveResult<R> {
+    pub fn save_all(&mut self) -> EntriesSaveResult<&mut Self> {
         self.save().temp()
     }
 
@@ -163,7 +163,7 @@ impl<R: Read> Multipart<R> {
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
     #[deprecated = "use `.save().with_temp_dir()` instead"]
-    pub fn save_all_under<P: AsRef<Path>>(&mut self, dir: P) -> EntriesSaveResult<R> {
+    pub fn save_all_under<P: AsRef<Path>>(&mut self, dir: P) -> EntriesSaveResult<&mut Self> {
         match TempDir::new_in(dir, "multipart") {
             Ok(temp_dir) => self.save().with_temp_dir(temp_dir),
             Err(err) => return SaveResult::Error(err),
@@ -178,8 +178,8 @@ impl<R: Read> Multipart<R> {
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
     #[deprecated = "use `.save().limit(limit)` instead"]
-    pub fn save_all_limited(&mut self, limit: u64) -> EntriesSaveResult<R> {
-        self.save().limit(limit).temp()
+    pub fn save_all_limited(&mut self, limit: u64) -> EntriesSaveResult<&mut Self> {
+        self.save().size_limit(limit).temp()
     }
 
     /// Read the request fully, parsing all fields and saving all files in a new temporary
@@ -190,9 +190,9 @@ impl<R: Read> Multipart<R> {
     /// If there is an error in reading the request, returns the partial result along with the
     /// error. See [`SaveResult`](enum.SaveResult.html) for more information.
     #[deprecated = "use `.save().limit(limit).with_temp_dir()` instead"]
-    pub fn save_all_under_limited<P: AsRef<Path>>(&mut self, dir: P, limit: u64) -> EntriesSaveResult<R> {
+    pub fn save_all_under_limited<P: AsRef<Path>>(&mut self, dir: P, limit: u64) -> EntriesSaveResult<&mut Self> {
         match TempDir::new_in(dir, "multipart") {
-            Ok(temp_dir) => self.save().limit(limit).with_temp_dir(temp_dir),
+            Ok(temp_dir) => self.save().size_limit(limit).with_temp_dir(temp_dir),
             Err(err) => return SaveResult::Error(err),
         }
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -141,6 +141,7 @@ impl<R: Read> Multipart<R> {
         }
     }
 
+    /// Get a builder type for saving the files in this request to the filesystem.
     pub fn save(&mut self) -> SaveBuilder<&mut Self> {
         SaveBuilder::new(self)
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -17,11 +17,9 @@ extern crate safemem;
 extern crate twoway;
 
 use std::borrow::Borrow;
-use std::collections::HashMap;
-use std::fs;
 use std::io::prelude::*;
-use std::path::{Path, PathBuf};
-use std::{io, mem};
+use std::path::Path;
+use std::io;
 
 use tempdir::TempDir;
 

--- a/src/server/save.rs
+++ b/src/server/save.rs
@@ -49,14 +49,14 @@ macro_rules! try_start (
 /// `mod_open_opts()`.
 ///
 /// ### File Size and Count Limits
-/// You can set a size limit for individual files with `limit()`, which takes either `u64`
+/// You can set a size limit for individual files with `size_limit()`, which takes either `u64`
 /// or `Option<u64>`.
 ///
 /// You can also set the maximum number of files to process with `count_limit()`, which
 /// takes either `u32` or `Option<u32>`. This only has an effect when using
-/// `SaveBuilder<Multipart>`.
+/// `SaveBuilder<[&mut] Multipart>`.
 ///
-/// ### Warning: Do **not* trust user input!
+/// ### Warning: Do **not** trust user input!
 /// It is a serious security risk to create files or directories with paths based on user input.
 /// A malicious user could craft a path which can be used to overwrite important files, such as
 /// web templates, static assets, Javascript files, database files, configuration files, etc.,
@@ -109,6 +109,7 @@ impl<S> SaveBuilder<S> {
     }
 }
 
+/// Save API for whole multipart requests.
 impl<M> SaveBuilder<M> where M: ReadEntry {
     /// Set the maximum number of files to write out.
     ///
@@ -119,7 +120,7 @@ impl<M> SaveBuilder<M> where M: ReadEntry {
     }
 
     /// Save the file fields in the request to a new temporary directory prefixed with
-    /// "multipart-rs" in the OS temporary directory.
+    /// `multipart-rs` in the OS temporary directory.
     ///
     /// For more options, create a `TempDir` yourself and pass it to `with_temp_dir()` instead.
     ///
@@ -152,7 +153,7 @@ impl<M> SaveBuilder<M> where M: ReadEntry {
 
     /// Save the file fields in the request to a new permanent directory with the given path.
     ///
-    /// Any nonexistent parent directories will be created.
+    /// Any nonexistent directories in the path will be created.
     pub fn with_dir<P: Into<PathBuf>>(self, dir: P) -> EntriesSaveResult<M> {
         let dir = dir.into();
 
@@ -239,6 +240,7 @@ impl<M> SaveBuilder<M> where M: ReadEntry {
     }
 }
 
+/// Save API for individual files.
 impl<'m, M: 'm> SaveBuilder<&'m mut MultipartFile<M>> where MultipartFile<M>: BufRead {
 
     /// Save to a file with a random alphanumeric name in the OS temporary directory.

--- a/src/server/save.rs
+++ b/src/server/save.rs
@@ -1,0 +1,501 @@
+// Copyright 2016 `multipart` Crate Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+//! Utilities for saving request entries to the filesystem.
+
+use super::buf_redux::copy_buf;
+
+use mime::Mime;
+
+use super::field::{MultipartData, MultipartFile};
+use super::Multipart;
+
+pub use tempdir::TempDir;
+
+use std::collections::HashMap;
+use std::io::prelude::*;
+use std::fs::OpenOptions;
+use std::path::{Path, PathBuf};
+use std::{env, fs, io, mem};
+
+const RANDOM_FILENAME_LEN: usize = 12;
+
+// Because this isn't exposed as a str in the stdlib
+#[cfg(not(windows))]
+const PATH_SEP: &'static str = "/";
+#[cfg(windows)]
+const PATH_SEP: &'static str = "\\";
+
+fn rand_filename() -> String {
+    ::random_alphanumeric(RANDOM_FILENAME_LEN)
+}
+
+/// A builder for saving a file or files to the local filesystem.
+///
+/// ### `OpenOptions`
+/// This builder holds an instance of `std::fs::OpenOptions` which is used
+/// when creating the new file(s).
+///
+/// By default, the open options are set with `.write(true).create_new(true)`,
+/// so if the file already exists then an error will be thrown. This is to avoid accidentally
+/// overwriting files from other requests.
+///
+/// If you want to modify the options used to open the save file, you can use
+/// `mod_open_opts()`.
+///
+/// ### File Size and Count Limits
+/// You can set a size limit for individual files with `limit()`, which takes either `u64`
+/// or `Option<u64>`.
+///
+/// You can also set the maximum number of files to process with `count_limit()`, which
+/// takes either `u32` or `Option<u32>`. This only has an effect when using
+/// `SaveBuilder<Multipart>`.
+///
+/// ### Warning: Do **not* trust user input!
+/// It is a serious security risk to create files or directories with paths based on user input.
+/// A malicious user could craft a path which can be used to overwrite important files, such as
+/// web templates, static assets, Javascript files, database files, configuration files, etc.,
+/// if they are writable by the server process.
+///
+/// This can be mitigated somewhat by setting filesystem permissions as
+/// conservatively as possible and running the server under its own user with restricted
+/// permissions, but you should still not use user input directly as filesystem paths.
+/// If it is truly necessary, you should sanitize user input such that it cannot cause a path to be
+/// misinterpreted by the OS. Such functionality is outside the scope of this crate.
+#[must_use = "nothing saved to the filesystem yet"]
+pub struct SaveBuilder<'s, S: 's> {
+    savable: &'s mut S,
+    open_opts: OpenOptions,
+    limit: Option<u64>,
+    count_limit: Option<u32>,
+}
+
+impl<'s, S: 's> SaveBuilder<'s, S> {
+    /// Implementation detail but not problematic to have accessible.
+    #[doc(hidden)]
+    pub fn new(savable: &'s mut S) -> SaveBuilder<'s, S> {
+        let mut open_opts = OpenOptions::new();
+        open_opts.write(true).create_new(true);
+
+        SaveBuilder {
+            savable: savable,
+            open_opts: open_opts,
+            limit: None,
+            count_limit: None,
+        }
+    }
+
+    /// Set the maximum number of bytes to write out *per file*.
+    ///
+    /// Can be `u64` or `Option<u64>`. If `None`, clears the limit.
+    pub fn limit<L: Into<Option<u64>>>(&mut self, limit: L) -> &mut Self {
+        self.limit = limit.into();
+        self
+    }
+
+    /// Modify the `OpenOptions` used to open any files for writing.
+    ///
+    /// The `write` flag will be reset to `true` after the closure returns. (It'd be pretty
+    /// pointless otherwise, right?)
+    pub fn mod_open_opts<F: FnOnce(&mut OpenOptions)>(&mut self, opts_fn: F) -> &mut Self {
+        opts_fn(&mut self.open_opts);
+        self.open_opts.write(true);
+        self
+    }
+}
+
+impl<'s, R: 's> SaveBuilder<'s, Multipart<R>> where R: Read {
+    /// Set the maximum number of files to write out.
+    ///
+    /// Can be `u32` or `Option<u32>`. If `None`, clears the limit.
+    pub fn count_limit<L: Into<Option<u32>>>(&mut self, count_limit: L) -> &mut Self {
+        self.count_limit = count_limit.into();
+        self
+    }
+
+    /// Save the file fields in the request to a new temporary directory prefixed with
+    /// "multipart-rs" in the OS temporary directory.
+    ///
+    /// For more options, create a `TempDir` yourself and pass it to `with_temp_dir()` instead.
+    ///
+    /// ### Note: Temporary
+    /// See `SaveDir` for more info (the type of `Entries::save_dir`).
+    pub fn temp(&mut self) -> SaveResult {
+        self.temp_with_prefix("multipart-rs")
+    }
+
+    /// Save the file fields in the request to a new temporary directory with the given string
+    /// as a prefix in the OS temporary directory.
+    ///
+    /// For more options, create a `TempDir` yourself and pass it to `with_temp_dir()` instead.
+    ///
+    /// ### Note: Temporary
+    /// See `SaveDir` for more info (the type of `Entries::save_dir`).
+    pub fn temp_with_prefix(&mut self, prefix: &str) -> SaveResult {
+        match TempDir::new(prefix) {
+            Ok(tempdir) => self.with_temp_dir(tempdir),
+            Err(e) => SaveResult::Error(e),
+        }
+    }
+
+    /// Save the file fields in the request to a new permanent directory with the given path.
+    ///
+    /// Any nonexistent parent directories will be created.
+    pub fn with_dir<P: Into<PathBuf>>(&mut self, dir: P) -> SaveResult {
+        let dir = dir.into();
+
+        if let Err(e) = create_dir_all(&dir) {
+            return SaveResult::Error(e);
+        };
+
+        self.with_save_dir(SaveDir::Perm(dir.into()))
+    }
+
+    /// Save the file fields to the given `TempDir`.
+    ///
+    /// The `TempDir` is returned in the result under `Entries::save_dir`.
+    pub fn with_temp_dir(&mut self, tempdir: TempDir) -> SaveResult {
+        self.with_save_dir(SaveDir::Temp(tempdir))
+    }
+
+    fn with_save_dir(&mut self, save_dir: SaveDir) -> SaveResult {
+        let mut entries = Entries::new(save_dir);
+
+        let mut count = 0;
+
+        loop {
+            let field = match self.savable.read_entry() {
+                Ok(Some(field)) => field,
+                Ok(None) => break,
+                Err(e) => return SaveResult::Partial(entries, e),
+            };
+
+            match field.data {
+                MultipartData::File(mut file) => {
+                    match self.count_limit {
+                        Some(limit) if count >= limit => return SaveResult::LimitHit(entries),
+                        _ => (),
+                    }
+
+                    match file.save().limit(self.limit).with_dir(&entries.save_dir) {
+                        Ok(saved_file) => entries.files.entry(field.name).or_insert(Vec::new())
+                                            .push(saved_file),
+                        Err(e) => return SaveResult::Partial(entries, e),
+                    }
+
+                    count += 1;
+                },
+                MultipartData::Text(text) => {
+                    entries.fields.insert(field.name, text.text);
+                },
+            }
+        }
+
+        SaveResult::Full(entries)
+    }
+}
+
+impl<'s, M: 's> SaveBuilder<'s, MultipartFile<M>> where MultipartFile<M>: BufRead {
+    /// Save to a file with a random alphanumeric name in the given directory.
+    ///
+    /// See `with_path()` for more details.
+    ///
+    /// ### Warning: Do **not* trust user input!
+    /// It is a serious security risk to create files or directories with paths based on user input.
+    /// A malicious user could craft a path which can be used to overwrite important files, such as
+    /// web templates, static assets, Javascript files, database files, configuration files, etc.,
+    /// if they are writable by the server process.
+    ///
+    /// This can be mitigated somewhat by setting filesystem permissions as
+    /// conservatively as possible and running the server under its own user with restricted
+    /// permissions, but you should still not use user input directly as filesystem paths.
+    /// If it is truly necessary, you should sanitize filenames such that they cannot be
+    /// misinterpreted by the OS.
+    pub fn with_dir<P: AsRef<Path>>(&mut self, dir: P) -> io::Result<SavedFile> {
+        let path = dir.as_ref().join(rand_filename());
+        self.with_path(path)
+    }
+
+    /// Save to a file with the given name in the OS temporary directory.
+    ///
+    /// See `with_path()` for more details.
+    ///
+    /// ### Warning: Do **not* trust user input!
+    /// It is a serious security risk to create files or directories with paths based on user input.
+    /// A malicious user could craft a path which can be used to overwrite important files, such as
+    /// web templates, static assets, Javascript files, database files, configuration files, etc.,
+    /// if they are writable by the server process.
+    ///
+    /// This can be mitigated somewhat by setting filesystem permissions as
+    /// conservatively as possible and running the server under its own user with restricted
+    /// permissions, but you should still not use user input directly as filesystem paths.
+    /// If it is truly necessary, you should sanitize filenames such that they cannot be
+    /// misinterpreted by the OS.
+    pub fn with_filename(&mut self, filename: &str) -> io::Result<SavedFile> {
+        let mut tempdir = env::temp_dir();
+        tempdir.set_file_name(filename);
+
+        self.with_path(tempdir)
+    }
+
+    /// Save to a file with the given path.
+    ///
+    /// Creates any missing directories in the path.
+    /// Uses the contained `OpenOptions` to create the file.
+    /// Truncates the file to the given limit, if set.
+    pub fn with_path<P: Into<PathBuf>>(&mut self, path: P) -> io::Result<SavedFile> {
+        let path = path.into();
+
+        try!(create_dir_all(&path));
+
+        let file = try!(self.open_opts.open(&path));
+        let (written, truncated) = try!(self.write_to(file));
+
+        Ok(SavedFile {
+            path: path,
+            filename: self.savable.filename.clone(),
+            content_type: self.savable.content_type.clone(),
+            size: written,
+            truncated: truncated,
+            _priv: (),
+        })
+    }
+
+    /// Save to a file with a random alphanumeric name in the OS temporary directory.
+    ///
+    /// Does not use user input to create the path.
+    ///
+    /// See `with_path()` for more details.
+    pub fn temp(&mut self) -> io::Result<SavedFile> {
+        let path = env::temp_dir().join(rand_filename());
+        self.with_path(path)
+    }
+
+    /// Write out the file field to `dest`, truncating if a limit was set.
+    ///
+    /// Returns the number of bytes copied, and whether or not the limit was reached
+    /// (tested by `MultipartFile::fill_buf().is_empty()` so no bytes are consumed).
+    ///
+    /// Retries on interrupts.
+    pub fn write_to<W: Write>(&mut self, mut dest: W) -> io::Result<(u64, bool)> {
+        if let Some(limit) = self.limit {
+            let copied = try!(copy_buf(&mut self.savable.by_ref().take(limit), &mut dest));
+            // If there's more data to be read, the field was truncated
+            Ok((copied, !try!(self.savable.fill_buf()).is_empty()))
+        } else {
+            copy_buf(&mut self.savable, &mut dest).map(|copied| (copied, false))
+        }
+    }
+}
+
+/// A file saved to the local filesystem from a multipart request.
+#[derive(Debug)]
+pub struct SavedFile {
+    /// The complete path this file was saved at.
+    pub path: PathBuf,
+
+    /// ### Warning: Client Provided / Untrustworthy
+    /// You should treat this value as **untrustworthy** because it is an arbitrary string
+    /// provided by the client.
+    ///
+    /// It is a serious security risk to create files or directories with paths based on user input.
+    /// A malicious user could craft a path which can be used to overwrite important files, such as
+    /// web templates, static assets, Javascript files, database files, configuration files, etc.,
+    /// if they are writable by the server process.
+    ///
+    /// This can be mitigated somewhat by setting filesystem permissions as
+    /// conservatively as possible and running the server under its own user with restricted
+    /// permissions, but you should still not use user input directly as filesystem paths.
+    /// If it is truly necessary, you should sanitize filenames such that they cannot be
+    /// misinterpreted by the OS. Such functionality is outside the scope of this crate.
+    pub filename: Option<String>,
+
+    /// The MIME type (`Content-Type` value) of this file, if supplied by the client,
+    /// or `"applicaton/octet-stream"` otherwise.
+    ///
+    /// ### Note: Client Provided
+    /// Consider this value to be potentially untrustworthy, as it is provided by the client.
+    /// It may be inaccurate or entirely wrong, depending on how the client determined it.
+    ///
+    /// Some variants wrap arbitrary strings which could be abused by a malicious user if your
+    /// application performs any non-idempotent operations based on their value, such as
+    /// starting another program or querying/updating a database (web-search "SQL injection").
+    pub content_type: Mime,
+
+    /// The number of bytes written to the disk. May be truncated, check the `truncated` flag
+    /// before making any assumptions based on this number.
+    pub size: u64,
+
+    /// If the file save limit was hit and the saved file ended up truncated.
+    pub truncated: bool,
+    // Private field to prevent exhaustive matching for backwards compatibility
+    _priv: (),
+}
+
+/// A result of `Multipart::save_all()`.
+#[derive(Debug)]
+pub struct Entries {
+    /// The text fields of the multipart request, mapped by field name -> value.
+    pub fields: HashMap<String, String>,
+    /// A map of file field names to their contents saved on the filesystem.
+    pub files: HashMap<String, Vec<SavedFile>>,
+    /// The directory the files in this request were saved under; may be temporary or permanent.
+    pub save_dir: SaveDir,
+}
+
+impl Entries {
+    fn new(save_dir: SaveDir) -> Self {
+        Entries {
+            fields: HashMap::new(),
+            files: HashMap::new(),
+            save_dir: save_dir,
+        }
+    }
+}
+
+/// The save directory for `Entries`. May be temporary (delete-on-drop) or permanent.
+#[derive(Debug)]
+pub enum SaveDir {
+    /// This directory is temporary and will be deleted, along with its contents, when this wrapper
+    /// is dropped.
+    Temp(TempDir),
+    /// This directory is permanent and will be left on the filesystem when this wrapper is dropped.
+    Perm(PathBuf),
+}
+
+impl SaveDir {
+    /// Get the path of this directory, either temporary or permanent.
+    pub fn as_path(&self) -> &Path {
+        use self::SaveDir::*;
+        match *self {
+            Temp(ref tempdir) => tempdir.path(),
+            Perm(ref pathbuf) => &*pathbuf,
+        }
+    }
+
+    /// Returns `true` if this is a temporary directory which will be deleted on-drop.
+    pub fn is_temporary(&self) -> bool {
+        use self::SaveDir::*;
+        match *self {
+            Temp(_) => true,
+            Perm(_) => false,
+        }
+    }
+
+    /// Unwrap the `PathBuf` from `self`; if this is a temporary directory,
+    /// it will be converted to a permanent one.
+    pub fn into_path(self) -> PathBuf {
+        use self::SaveDir::*;
+
+        match self {
+            Temp(tempdir) => tempdir.into_path(),
+            Perm(pathbuf) => pathbuf,
+        }
+    }
+
+    /// If this `SaveDir` is temporary, convert it to permanent.
+    /// This is a no-op if it already is permanent.
+    ///
+    /// ### Warning: Potential Data Loss
+    /// Even though this will prevent deletion on-drop, the temporary folder on most OSes
+    /// (where this directory is created by default) can be automatically cleared by the OS at any
+    /// time, usually on reboot or when free space is low.
+    ///
+    /// It is recommended that you relocate the files from a request which you want to keep to a
+    /// permanent folder on the filesystem.
+    pub fn keep(&mut self) {
+        use self::SaveDir::*;
+        *self = match mem::replace(self, Perm(PathBuf::new())) {
+            Temp(tempdir) => Perm(tempdir.into_path()),
+            old_self => old_self,
+        };
+    }
+
+    /// Delete this directory and its contents, regardless of its permanence.
+    ///
+    /// ### Warning: Potential Data Loss
+    /// This is very likely irreversible, depending on the OS implementation.
+    ///
+    /// Files deleted programmatically are deleted directly from disk, as compared to most file
+    /// manager applications which use a staging area from which deleted files can be safely
+    /// recovered (i.e. Windows' Recycle Bin, OS X's Trash Can, etc.).
+    pub fn delete(self) -> io::Result<()> {
+        use self::SaveDir::*;
+        match self {
+            Temp(tempdir) => tempdir.close(),
+            Perm(pathbuf) => fs::remove_dir_all(&pathbuf),
+        }
+    }
+}
+
+impl AsRef<Path> for SaveDir {
+    fn as_ref(&self) -> &Path {
+        self.as_path()
+    }
+}
+
+/// The result of [`Multipart::save_all()`](struct.multipart.html#method.save_all)
+/// and methods on `SaveBuilder<Multipart>`.
+#[derive(Debug)]
+pub enum SaveResult {
+    /// The operation was a total success. Contained are all entries of the request.
+    Full(Entries),
+    /// The file count limit in the save operation was hit. Contained are the entries
+    /// that came in under the limit.
+    LimitHit(Entries),
+    /// The operation errored partway through. Contained are the entries gathered thus far,
+    /// as well as the error that ended the process.
+    Partial(Entries, io::Error),
+    /// The `TempDir` for `Entries` could not be constructed. Contained is the error detailing the
+    /// problem.
+    Error(io::Error),
+}
+
+impl SaveResult {
+    /// Take the `Entries` from `self`, if applicable, and discarding
+    /// the error, if any.
+    pub fn to_entries(self) -> Option<Entries> {
+        use self::SaveResult::*;
+
+        match self {
+            Full(entries) | LimitHit(entries) | Partial(entries, _) => Some(entries),
+            Error(_) => None,
+        }
+    }
+
+    /// Decompose `self` to `(Option<Entries>, Option<io::Error>)`
+    pub fn to_opt(self) -> (Option<Entries>, Option<io::Error>) {
+        use self::SaveResult::*;
+
+        match self {
+            Full(entries) => (Some(entries), None),
+            LimitHit(entries) => (Some(entries), None),
+            Partial(entries, error) => (Some(entries), Some(error)),
+            Error(error) => (None, Some(error)),
+        }
+    }
+
+    /// Map `self` to an `io::Result`, discarding the error in the `Partial` case.
+    pub fn to_result(self) -> io::Result<Entries> {
+        use self::SaveResult::*;
+
+        match self {
+            Full(entries) | LimitHit(entries) | Partial(entries, _) => Ok(entries),
+            Error(error) => Err(error),
+        }
+    }
+}
+
+fn create_dir_all(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+    } else {
+        // RFC: return an error instead?
+        warn!("Attempting to save file in what looks like a root directory. File path: {:?}", path);
+
+        Ok(())
+    }
+}

--- a/src/server/save.rs
+++ b/src/server/save.rs
@@ -521,6 +521,22 @@ impl From<io::Error> for PartialReason {
     }
 }
 
+impl PartialReason {
+    /// Return `io::Error` in the `IoError` case or panic otherwise.
+    pub fn unwrap_err(self) -> io::Error {
+        self.expect_err("`PartialReason` was not `IoError`")
+    }
+
+    /// Return `io::Error` in the `IoError` case or panic with the given
+    /// message otherwise.
+    pub fn expect_err(self, msg: &str) -> io::Error {
+        match self {
+            PartialReason::IoError(e) => e,
+            _ => panic!("{}: {:?}", msg, self),
+        }
+    }
+}
+
 /// The file field that was being read when the save operation quit.
 ///
 /// May be partially saved to the filesystem if `dest` is `Some`.


### PR DESCRIPTION
* Numerous bugfixes
* `MultipartField` and friends now parametric over owned/borrowed `Multipart`
* Get next entry (in or out of place)
* Adds builder type for file saving, more convenient to set limits or choose save locations
    * Deprecates the APIs it replaces


closes #60, closes #58, closes #54, closes #51, closes #66 