### PR TITLE
0.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
   except:
   - fuzzing
 rust:
-  - 1.14.0
+  - 1.15.0
   - stable
   - beta
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
   except:
   - fuzzing
 rust:
-  - 1.13.0
+  - 1.14.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "multipart"
 
-version = "0.12.0"
+version = "0.13.0"
 
 authors = ["Austin Bonander <austin.bonander@gmail.com>"]
 
-description = "A backend-agnostic extension for HTTP libraries that provides support for POST multipart/form-data requests on for both client and server."
+description = "A backend-agnostic extension for HTTP libraries that provides support for POST multipart/form-data requests on both client and server."
 
 keywords = ["form-data", "hyper", "iron", "http", "upload"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ log = "0.3"
 mime = "0.2"
 mime_guess = "1.8"
 rand = "0.3"
+safemem = { version = "0.2", optional = true }
 tempdir = ">=0.3.4"
 clippy = { version = ">=0.0, <0.1", optional = true}
 
 #Server Dependencies
 buf_redux = { version = "0.6", optional = true }
 httparse = { version = "1.2", optional = true }
-safemem = { version = "0.2", optional = true }
 twoway = { version = "0.1", optional = true }
 
 # Optional Integrations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ default = ["all"]
 server = ["buf_redux", "httparse", "safemem", "twoway"]
 mock = []
 nightly = []
+bench = []
 # Use this to enable SSE4.2 instructions in boundary finding
 # TODO: Benchmark this
 sse4 = ["nightly", "twoway/pcmp"]

--- a/nickel/Cargo.toml
+++ b/nickel/Cargo.toml
@@ -9,12 +9,13 @@ repository = "https://github.com/abonander/multipart"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-hyper = "0.9"
-nickel = "0.9"
+hyper = "0.10"
+nickel = "0.10"
 
 [dependencies.multipart]
-version = "0.12"
-# I had no idea you could also specify a path
+version = "0.13"
+# You can specify a path alongside the version so it can be tested against the latest code but published
+# against the released version
 path = "../"
 default-features = false
 features = ["hyper", "server"]

--- a/src/client/hyper.rs
+++ b/src/client/hyper.rs
@@ -24,12 +24,12 @@ use mime::{Mime, TopLevel, SubLevel, Attr, Value};
 
 use super::{HttpRequest, HttpStream};
 
-/// ####Feature: `hyper`
+/// #### Feature: `hyper`
 impl HttpRequest for Request<Fresh> {
     type Stream = Request<Streaming>;
     type Error = HyperError;
 
-    /// #Panics
+    /// # Panics
     /// If `self.method() != Method::Post`.
     fn apply_headers(&mut self, boundary: &str, content_len: Option<u64>) -> bool {
         if self.method() != Method::Post {
@@ -59,7 +59,7 @@ impl HttpRequest for Request<Fresh> {
     }
 } 
 
-/// ####Feature: `hyper`
+/// #### Feature: `hyper`
 impl HttpStream for Request<Streaming> {
     type Request = Request<Fresh>;
     type Response = Response;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -63,7 +63,7 @@ impl<S: HttpStream> Multipart<S> {
     /// Write a text field to this multipart request.
     /// `name` and `val` can be either owned `String` or `&str`.
     ///
-    /// ##Errors
+    /// ## Errors
     /// If something went wrong with the HTTP stream.
     pub fn write_text<N: AsRef<str>, V: AsRef<str>>(&mut self, name: N, val: V) -> Result<&mut Self, S::Error> {
         map_self!(self, self.writer.write_text(name.as_ref(), val.as_ref()))
@@ -77,7 +77,7 @@ impl<S: HttpStream> Multipart<S> {
     ///
     /// `name` can be either `String` or `&str`, and `path` can be `PathBuf` or `&Path`.
     ///
-    /// ##Errors
+    /// ## Errors
     /// If there was a problem opening the file (was a directory or didn't exist),
     /// or if something went wrong with the HTTP stream.
     pub fn write_file<N: AsRef<str>, P: AsRef<Path>>(&mut self, name: N, path: P) -> Result<&mut Self, S::Error> {
@@ -93,7 +93,7 @@ impl<S: HttpStream> Multipart<S> {
     /// `name` can be either `String` or `&str`, and `read` can take the `Read` by-value or
     /// with an `&mut` borrow.
     ///
-    /// ##Warning
+    /// ## Warning
     /// The given `Read` **must** be able to read to EOF (end of file/no more data), meaning
     /// `Read::read()` returns `Ok(0)`. If it never returns EOF it will be read to infinity 
     /// and the request will never be completed.
@@ -104,7 +104,7 @@ impl<S: HttpStream> Multipart<S> {
     /// Use `Read::take()` if you wish to send data from a `Read` 
     /// that will never return EOF otherwise.
     ///
-    /// ##Errors
+    /// ## Errors
     /// If the reader returned an error, or if something went wrong with the HTTP stream.
     // RFC: How to format this declaration?
     pub fn write_stream<N: AsRef<str>, St: Read>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@ extern crate mime_guess;
 extern crate rand;
 extern crate tempdir;
 
+extern crate safemem;
+
 #[cfg(feature = "hyper")]
 extern crate hyper;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
 #![cfg_attr(feature="clippy", deny(clippy))]
+#![cfg_attr(feature = "bench", feature(test))]
 #![deny(missing_docs)]
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //! Client- and server-side abstractions for HTTP `multipart/form-data` requests.
 //!
-//! ###Features:
+//! ### Features:
 //! This documentation is built with all features enabled.
 //!
 //! * `client`: The client-side abstractions for generating multipart requests.

--- a/src/local_test.rs
+++ b/src/local_test.rs
@@ -326,7 +326,7 @@ fn test_client_lazy(test_fields: &TestFields) -> HttpBuffer {
         }
     }
 
-    let mut prepared = multipart.prepare_threshold(None).unwrap();
+    let mut prepared = multipart.prepare().unwrap();
 
     let mut buf = Vec::new();
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -30,7 +30,7 @@ impl ::client::HttpRequest for ClientRequest {
         true
     }
 
-    /// ##Panics
+    /// ## Panics
     /// If `apply_headers()` was not called.
     fn open_stream(self) -> Result<HttpBuffer, io::Error> {
         debug!("ClientRequest::open_stream called! {:?}", self);

--- a/src/server/boundary.rs
+++ b/src/server/boundary.rs
@@ -7,8 +7,10 @@
 
 //! Boundary parsing for `multipart` requests.
 
+use ::safemem;
+
 use super::buf_redux::BufReader;
-use super::{safemem, twoway};
+use super::twoway;
 
 use log::LogLevel;
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -112,7 +112,7 @@ impl<R: Read> Multipart<R> {
     /// Read the next entry from this multipart request, returning a struct with the field's name and
     /// data. See `MultipartField` for more info.
     ///
-    /// ##Warning: Risk of Data Loss
+    /// ## Warning: Risk of Data Loss
     /// If the previously returned entry had contents of type `MultipartField::File`,
     /// calling this again will discard any unread contents of that entry.
     pub fn read_entry(&mut self) -> io::Result<Option<MultipartField<&mut Self>>> {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,7 +13,6 @@
 
 extern crate buf_redux;
 extern crate httparse;
-extern crate safemem;
 extern crate twoway;
 
 use std::borrow::Borrow;


### PR DESCRIPTION
* Adds basic benchmark
* Bumps minimum Rust version to 1.15
* Fixes a logic error in `lazy::PreparedFields` by just not trying as hard
* Fixes headers in doc-comments (Markdown rendering changed)

Closes #82 