### PR TITLE
Dependency to safemem is optional but required

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ extern crate mime_guess;
 extern crate rand;
 extern crate tempdir;
 
+#[cfg(feature = "server")]
 extern crate safemem;
 
 #[cfg(feature = "hyper")]


### PR DESCRIPTION
`safemem` crate is used only if `server` feature is enabled, but `extern crate safemem` is written without `#[cfg(feature = "server")]`. This causes compilation error if I compile it without `server` feature.

```
cargo build --features 'client hyper' --no-default-features
```

```
error[E0463]: can't find crate for `safemem`
  --> src\lib.rs:51:1
   |
51 | extern crate safemem;
   | ^^^^^^^^^^^^^^^^^^^^^ can't find crate
```