### PR TITLE
Compare header names case-insensitively

### DIFF
--- a/src/server/field.rs
+++ b/src/server/field.rs
@@ -743,3 +743,16 @@ impl From<httparse::Error> for ParseHeaderError {
         ParseHeaderError::Invalid(format!("{}", err))
     }
 }
+
+#[test]
+fn test_find_header() {
+    let headers = [
+        StrHeader { name: "Content-Type", val: "text/plain" },
+        StrHeader { name: "Content-disposition", val: "form-data" },
+        StrHeader { name: "content-transfer-encoding", val: "binary" }
+    ];
+
+    assert_eq!(find_header(&headers, "Content-Type").unwrap().val, "text/plain");
+    assert_eq!(find_header(&headers, "Content-Disposition").unwrap().val, "form-data");
+    assert_eq!(find_header(&headers, "Content-Transfer-Encoding").unwrap().val, "binary");
+}

--- a/src/server/field.rs
+++ b/src/server/field.rs
@@ -20,6 +20,8 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::{str, fmt, error};
 
+use std::ascii::AsciiExt;
+
 const EMPTY_STR_HEADER: StrHeader<'static> = StrHeader {
     name: "",
     val: "",
@@ -516,7 +518,9 @@ fn io_str_utf8(buf: &[u8]) -> io::Result<&str> {
 }
 
 fn find_header<'a, 'b>(headers: &'a [StrHeader<'b>], name: &str) -> Option<&'a StrHeader<'b>> {
-    headers.iter().find(|header| header.name == name)
+    /// Field names are case insensitive and consist of ASCII characters
+    /// only (see https://tools.ietf.org/html/rfc822#section-3.2).
+    headers.iter().find(|header| header.name.eq_ignore_ascii_case(name))
 }
 
 /// Common trait for `Multipart` and `&mut Multipart`


### PR DESCRIPTION
I've encountered parsing errors when processing a request from [hackney](https://github.com/benoitc/hackney) using this crate, and I've tracked those down to it not accepting lowercase subpart headers.

If I interpret the standards correctly, MIME headers (such as Content-Type) as specified in [RFC 2045](https://tools.ietf.org/html/rfc2045) follow the definitions from RFC 822. The relevant parts are:

> [field       =  field-name ":" [ field-body ] CRLF](https://tools.ietf.org/html/rfc822#section-3.2)
> [field-name  =  1*<any CHAR, excluding CTLs, SPACE, and ":">](https://tools.ietf.org/html/rfc822#section-3.2)
> [CHAR        =  \<any ASCII character>](https://tools.ietf.org/html/rfc822#section-3.3)
> ...
> [Except as noted, alphabetic strings may be represented in  any combination of upper and lower case.](https://tools.ietf.org/html/rfc822#section-3.4.7)

This means that, for example, "Content-Type" and "content-type" are both valid Content-Type headers.

I've changed header comparisons to account for this. I'm not sure how to test this, though; do you have any suggestions?