### PR TITLE
Switch from tempdir to tempfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
   except:
   - fuzzing
 rust:
-  - 1.22.1
+  - 1.24.1
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-# lazy-static (pulled in by e.g. nickel, regex) is incompatible with 1.22.1
-lazy_static = { version = ">=1.0,<1.2.0", optional = true }
+lazy_static = { version = "1.2.0", optional = true }
 log = "0.4"
 mime = "0.2"
 mime_guess = "1.8"
@@ -55,7 +54,7 @@ nightly = []
 bench = []
 # Use this to enable SSE4.2 instructions in boundary finding
 # TODO: Benchmark this
-sse4 = ["nightly", "twoway/pcmp"]
+sse4 = ["nightly"]
 # switch uses of `Arc<String>` for `Arc<str>` (`From<String>` impl only stabilized in 1.21)
 use_arc_str = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ mime = "0.2"
 mime_guess = "1.8"
 rand = "0.6"
 safemem = { version = "0.3", optional = true }
-tempdir = "0.3"
+tempfile = "3"
 clippy = { version = ">=0.0, <0.1", optional = true}
 
 #Server Dependencies

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Client- and server-side abstractions for HTTP file uploads (POST requests with  
 Supports several different (**sync**hronous API) HTTP crates. 
 **Async**hronous (i.e. `futures`-based) API support will be provided by [multipart-async].
 
-Minimum supported Rust version: 1.22.1
+Minimum supported Rust version: 1.24.1
 
 ### [Documentation](http://docs.rs/multipart/)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ extern crate log;
 extern crate mime;
 extern crate mime_guess;
 extern crate rand;
-extern crate tempdir;
+extern crate tempfile;
 
 #[cfg(feature = "quick-error")]
 #[macro_use]

--- a/src/server/iron.rs
+++ b/src/server/iron.rs
@@ -11,6 +11,7 @@ use iron::{BeforeMiddleware, IronError, IronResult};
 
 use std::path::PathBuf;
 use std::{error, fmt, io};
+use tempfile;
 
 use super::{FieldHeaders, HttpRequest, Multipart};
 use super::save::{Entries, PartialReason, TempDir};
@@ -126,8 +127,8 @@ impl Intercept {
 
         let tempdir = self.temp_dir_path.as_ref()
                 .map_or_else(
-                    || TempDir::new("multipart-iron"),
-                    |path| TempDir::new_in(path, "multipart-iron")
+                    || tempfile::Builder::new().prefix("multipart-iron").tempdir(),
+                    |path| tempfile::Builder::new().prefix("multipart-iron").tempdir_in(path)
                 )
                 .map_err(|e| io_to_iron(e, "Error opening temporary directory for request."))?;
 

--- a/src/server/save.rs
+++ b/src/server/save.rs
@@ -8,13 +8,14 @@
 
 pub use server::buf_redux::BufReader;
 
-pub use tempdir::TempDir;
+pub use tempfile::TempDir;
 
 use std::collections::HashMap;
 use std::io::prelude::*;
 use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::{cmp, env, io, mem, str, u32, u64};
+use tempfile;
 
 use server::field::{FieldHeaders, MultipartField, MultipartData, ReadEntry, ReadEntryResult};
 use server::ArcStr;
@@ -247,7 +248,7 @@ impl<M> SaveBuilder<M> where M: ReadEntry {
     /// ### Note: Temporary
     /// See `SaveDir` for more info (the type of `Entries::save_dir`).
     pub fn temp_with_prefix(self, prefix: &str) -> EntriesSaveResult<M> {
-        match TempDir::new(prefix) {
+        match tempfile::Builder::new().prefix(prefix).tempdir() {
             Ok(tempdir) => self.with_temp_dir(tempdir),
             Err(e) => SaveResult::Error(e),
         }


### PR DESCRIPTION
According to the tempdir repository, tempdir has been deprecated
and replaced with tempfile:

https://github.com/rust-lang-deprecated/tempdir#deprecation-note

The current api publicly exposes the `tempdir::TempDir` type,
so this patch is a breaking change to the public api, so I bumped
the major version in the Cargo.toml file.