### PR TITLE
Bump minimum rust version to 1.26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
   except:
   - fuzzing
 rust:
-  - 1.22.1
+  - 1.26
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Client- and server-side abstractions for HTTP file uploads (POST requests with  
 Supports several different (**sync**hronous API) HTTP crates. 
 **Async**hronous API support will be provided by [multipart-async].
 
-Minimum supported Rust version: 1.22.1
+Minimum supported Rust version: 1.26
 
 ### [Documentation](http://docs.rs/multipart/)
 


### PR DESCRIPTION
The dependency `buf_redux` depends on the crate `slice-deque`,
which uses some features that stablized in rust 1.26.