### PR TITLE
Fix incomplete multipart problem

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -257,7 +257,7 @@ impl<'a, W: Write> MultipartWriter<'a, W> {
         }
 
         // always write the closing boundary, even for empty bodies
-        write!(self.inner, "--{}--", self.boundary)?;
+        write!(self.inner, "--{}--\r\n", self.boundary)?;
         Ok(self.inner)
     }
 }


### PR DESCRIPTION
Seems like hyper is reading until it sees `\r\n`, and since that's not being sent, I get 

```
ERROR 2018-11-20T08:47:28Z: actix_web::pipeline: Error occurred during request handling, status: 500 Internal Server Error Multipart stream is incomplete
```

This just adds the `\r\n` to the end so hyper has no problem seeing it.