### PR TITLE
Bump rand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
   except:
   - fuzzing
 rust:
-  - 1.26.1
+  - 1.22.1
   - stable
   - beta
   - nightly
@@ -16,7 +16,6 @@ env:
    - RUST_LOG=multipart=trace RUST_BACKTRACE=1 ARGS=
 matrix:
   include:
-    - rust: 1.22.1
     - rust: stable
       env: ARGS+=--no-default-features --features "nickel"
     - rust: stable
@@ -24,11 +23,6 @@ matrix:
     - rust: nightly
       env: ARGS+=--features "nightly,rocket"
 script:
-  - |
-    if [ ${TRAVIS_RUST_VERSION} = "1.22.1" ]; then
-        # we can't test because `env_logger` uses `lazy_static 1.2.0` which needs Rust 1.26
-        cargo build --no-default-features --features "mock,client,server" && exit 0;
-    fi
   - cargo build --verbose $ARGS;
   - cargo test --verbose $ARGS -- --test-threads=1;
   - cargo doc --verbose $ARGS;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lazy_static = { version = ">=1.0,<1.2.0", optional = true }
 log = "0.4"
 mime = "0.2"
 mime_guess = "1.8"
-rand = "0.4"
+rand = "0.6"
 safemem = { version = "0.3", optional = true }
 tempdir = "0.3"
 clippy = { version = ">=0.0, <0.1", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
+# lazy-static (pulled in by e.g. nickel, regex) is incompatible with 1.22.1
+lazy_static = { version = ">=1.0,<1.2.0", optional = true }
 log = "0.4"
 mime = "0.2"
 mime_guess = "1.8"

--- a/README.md
+++ b/README.md
@@ -5,10 +5,7 @@ Client- and server-side abstractions for HTTP file uploads (POST requests with  
 Supports several different (**sync**hronous API) HTTP crates. 
 **Async**hronous (i.e. `futures`-based) API support will be provided by [multipart-async].
 
-Minimum supported Rust version: 1.22.1*
-* only `mock`, `client` and `server` features, only guaranteed to compile
-
-Fully tested Rust version: 1.26.1
+Minimum supported Rust version: 1.22.1
 
 ### [Documentation](http://docs.rs/multipart/)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ pub mod server;
 mod local_test;
 
 fn random_alphanumeric(len: usize) -> String {
-    rand::thread_rng().gen_ascii_chars().take(len).collect()
+    rand::thread_rng().sample_iter(&rand::distributions::Alphanumeric).take(len).collect()
 }
 
 #[cfg(test)]

--- a/src/local_test.rs
+++ b/src/local_test.rs
@@ -301,6 +301,8 @@ fn gen_bool() -> bool {
 }
 
 fn gen_string() -> String {
+    use rand::distributions::Alphanumeric;
+
     let mut rng_1 = rand::thread_rng();
     let mut rng_2 = rand::thread_rng();
 
@@ -308,9 +310,9 @@ fn gen_string() -> String {
     let str_len_2 = rng_2.gen_range(MIN_LEN, MAX_LEN + 1);
     let num_dashes = rng_1.gen_range(0, MAX_DASHES + 1);
 
-    rng_1.gen_ascii_chars().take(str_len_1)
+    rng_1.sample_iter(&Alphanumeric).take(str_len_1)
         .chain(iter::repeat('-').take(num_dashes))
-        .chain(rng_2.gen_ascii_chars().take(str_len_2))
+        .chain(rng_2.sample_iter(&Alphanumeric).take(str_len_2))
         .collect()
 }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -9,7 +9,8 @@ use std::cell::{Cell, RefCell};
 use std::io::{self, Read, Write};
 use std::{fmt, thread};
 
-use rand::{self, Rng, ThreadRng};
+use rand::{self, Rng};
+use rand::prelude::ThreadRng;
 
 /// A mock implementation of `client::HttpRequest` which can spawn an `HttpBuffer`.
 ///


### PR DESCRIPTION
Upgrade `rand` to `0.6`, changing only the use of some APIs in tests.

Pin `lazy_static` to <1.2, as newer versions break compilation with rustc 1.22.1.