### PR TITLE
Use lazy_static 1.2.0, remove twoway/pcmp and require rust 1.24.1+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
   except:
   - fuzzing
 rust:
-  - 1.22.1
+  - 1.24.1
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-# lazy-static (pulled in by e.g. nickel, regex) is incompatible with 1.22.1
-lazy_static = { version = ">=1.0,<1.2.0", optional = true }
+lazy_static = { version = "1.2.0", optional = true }
 log = "0.4"
 mime = "0.2"
 mime_guess = "1.8"
@@ -55,7 +54,7 @@ nightly = []
 bench = []
 # Use this to enable SSE4.2 instructions in boundary finding
 # TODO: Benchmark this
-sse4 = ["nightly", "twoway/pcmp"]
+sse4 = ["nightly"]
 # switch uses of `Arc<String>` for `Arc<str>` (`From<String>` impl only stabilized in 1.21)
 use_arc_str = []
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Client- and server-side abstractions for HTTP file uploads (POST requests with  
 Supports several different (**sync**hronous API) HTTP crates. 
 **Async**hronous (i.e. `futures`-based) API support will be provided by [multipart-async].
 
-Minimum supported Rust version: 1.22.1
+Minimum supported Rust version: 1.24.1
 
 ### [Documentation](http://docs.rs/multipart/)
 


### PR DESCRIPTION
Attempt number two :)

Before this patch, multipart got into an impossible sitation with it's dependencies. It errs with:

```
error: failed to select a version for `lazy_static`.
    ... required by package `multipart v0.15.4`
versions that meet the requirements `>= 1.0, < 1.2.0` are: 1.1.0, 1.0.2, 1.0.1, 1.0.0

all possible versions conflict with previously selected packages.

  previously selected package `lazy_static v1.2.0`
    ... which is depended on by `ring v0.13.5`
    ... which is depended on by `cookie v0.11.0`
    ... which is depended on by `rocket_http v0.4.0`
    ... which is depended on by `rocket v0.4.0`
    ... which is depended on by `multipart v0.15.4
```

This is due to ring 0.13.3 bumping lazy_static to 1.2.0 to avoid a [soundness bug](https://github.com/rust-lang-nursery/lazy-static.rs/issues/117). This patch fixes this problem by requiring at least rust 1.24.1.

In addition, I noticed that the feature sse4 was depending on `twoway/pcmp`, but that has been [removed](https://github.com/bluss/twoway/pull/8).