### PR TITLE
Update mime dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "multipart"
 
-version = "0.16.1"
+version = "0.16.2"
 
 authors = ["Austin Bonander <austin.bonander@gmail.com>"]
 
@@ -20,8 +20,8 @@ readme = "README.md"
 [dependencies]
 lazy_static = { version = "1.2.0", optional = true }
 log = "0.4"
-mime = "0.2"
-mime_guess = "1.8"
+mime = "0.3"
+mime_guess = "2.0"
 rand = "0.6"
 safemem = { version = "0.3", optional = true }
 tempfile = "3"

--- a/src/local_test.rs
+++ b/src/local_test.rs
@@ -146,7 +146,7 @@ impl FileEntry {
 
         (
             FileEntry {
-                content_type: field.headers.content_type.unwrap_or(mime!(Application/OctetStream)),
+                content_type: field.headers.content_type.unwrap_or(mime::APPLICATION_OCTET_STREAM),
                 filename: field.headers.filename,
                 data: PrintHex(data),
             },
@@ -435,8 +435,8 @@ fn rand_mime() -> Mime {
     [
         // TODO: fill this out, preferably with variants that may be hard to parse
         // i.e. containing hyphens, mainly
-        mime!(Application/OctetStream),
-        mime!(Text/Plain),
-        mime!(Image/Png),
+        mime::APPLICATION_OCTET_STREAM,
+        mime::TEXT_PLAIN,
+        mime::IMAGE_PNG,
     ].choose(&mut rand::thread_rng()).unwrap().clone()
 }

--- a/src/server/field.rs
+++ b/src/server/field.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 //! `multipart` field header parsing.
-use mime::{Mime, TopLevel};
+use mime::Mime;
 
 use std::error::Error;
 use std::io::{self, Read, BufRead};
@@ -225,7 +225,7 @@ impl<M: ReadEntry> MultipartField<M> {
     ///
     /// Detecting character encodings by any means is (currently) beyond the scope of this crate.
     pub fn is_text(&self) -> bool {
-        self.headers.content_type.as_ref().map_or(true, |ct| ct.0 == TopLevel::Text)
+        self.headers.content_type.as_ref().map_or(true, |ct| ct.type_() == mime::TEXT)
     }
 
     /// Read the next entry in the request.
@@ -365,7 +365,7 @@ pub trait ReadEntry: PrivReadEntry + Sized {
         let field_headers: FieldHeaders = try_read_entry!(self; self.read_headers());
 
         if let Some(ct) = field_headers.content_type.as_ref() {
-            if ct.0 == TopLevel::Multipart {
+            if ct.type_() == mime::MULTIPART {
                 // fields of this type are sent by (supposedly) no known clients
                 // (https://tools.ietf.org/html/rfc7578#appendix-A) so I'd be fascinated
                 // to hear about any in the wild


### PR DESCRIPTION
Having this on crates.io would help avoid duplicating dependencies in Servo and Firefox. I’ve bumped the version number based on the assumption that the `mime` and `mime_guess` are private dependencies (their items do not appear in `multipart`’s public API), is that correct?