### PR TITLE
Bump rand to 0.7 to address RUSTSEC-2019-0035

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = { version = "1.2.0", optional = true }
 log = "0.4"
 mime = "0.3.14"
 mime_guess = "2.0.1"
-rand = "0.6"
+rand = "0.7"
 safemem = { version = "0.3", optional = true }
 tempfile = "3"
 clippy = { version = ">=0.0, <0.1", optional = true}


### PR DESCRIPTION
rand<0.7 depends on rand_core 0.3 which suffers from https://rustsec.org/advisories/RUSTSEC-2019-0035

cargo test passes but I'll be happy run additional tests if you can advise me which ones/how.