### PR TITLE
Update to rand 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = { version = "1.2.0", optional = true }
 log = "0.4"
 mime = "0.3.14"
 mime_guess = "2.0.1"
-rand = "0.7"
+rand = "0.8"
 safemem = { version = "0.3", optional = true }
 tempfile = "3"
 clippy = { version = ">=0.0, <0.1", optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@ fn random_alphanumeric(len: usize) -> String {
     rand::thread_rng()
         .sample_iter(&rand::distributions::Alphanumeric)
         .take(len)
+        .map(char::from)
         .collect()
 }
 

--- a/src/local_test.rs
+++ b/src/local_test.rs
@@ -28,7 +28,7 @@ const MAX_LEN: usize = 5;
 const MAX_DASHES: usize = 2;
 
 fn collect_rand<C: FromIterator<T>, T, F: FnMut() -> T>(mut gen: F) -> C {
-    (0..rand::thread_rng().gen_range(MIN_FIELDS, MAX_FIELDS))
+    (0..rand::thread_rng().gen_range(MIN_FIELDS..MAX_FIELDS))
         .map(|_| gen())
         .collect()
 }
@@ -326,15 +326,21 @@ fn gen_string() -> String {
     let mut rng_1 = rand::thread_rng();
     let mut rng_2 = rand::thread_rng();
 
-    let str_len_1 = rng_1.gen_range(MIN_LEN, MAX_LEN + 1);
-    let str_len_2 = rng_2.gen_range(MIN_LEN, MAX_LEN + 1);
-    let num_dashes = rng_1.gen_range(0, MAX_DASHES + 1);
+    let str_len_1 = rng_1.gen_range(MIN_LEN..MAX_LEN + 1);
+    let str_len_2 = rng_2.gen_range(MIN_LEN..MAX_LEN + 1);
+    let num_dashes = rng_1.gen_range(0..MAX_DASHES + 1);
 
     rng_1
         .sample_iter(&Alphanumeric)
         .take(str_len_1)
+        .map(char::from)
         .chain(iter::repeat('-').take(num_dashes))
-        .chain(rng_2.sample_iter(&Alphanumeric).take(str_len_2))
+        .chain(
+            rng_2
+                .sample_iter(&Alphanumeric)
+                .take(str_len_2)
+                .map(char::from),
+        )
         .collect()
 }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -5,11 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 //! Mocked types for client-side and server-side APIs.
-use std::io::{self, Read, Write};
 use std::fmt;
+use std::io::{self, Read, Write};
 
-use rand::{self, Rng};
 use rand::prelude::ThreadRng;
+use rand::{self, Rng};
 
 /// A mock implementation of `client::HttpRequest` which can spawn an `HttpBuffer`.
 ///
@@ -35,12 +35,13 @@ impl ::client::HttpRequest for ClientRequest {
     /// If `apply_headers()` was not called.
     fn open_stream(self) -> Result<HttpBuffer, io::Error> {
         debug!("ClientRequest::open_stream called! {:?}", self);
-        let boundary = self.boundary.expect("ClientRequest::set_headers() was not called!");
+        let boundary = self
+            .boundary
+            .expect("ClientRequest::set_headers() was not called!");
 
         Ok(HttpBuffer::new_empty(boundary, self.content_len))
     }
 }
-
 
 /// A writable buffer which stores the boundary and content-length, if provided.
 ///
@@ -67,7 +68,7 @@ impl HttpBuffer {
             buf,
             boundary,
             content_len,
-            rng: rand::thread_rng()
+            rng: rand::thread_rng(),
         }
     }
 
@@ -92,7 +93,7 @@ impl Write for HttpBuffer {
         }
 
         // Simulate the randomness of a network connection by not always reading everything
-        let len = self.rng.gen_range(1, buf.len() + 1);
+        let len = self.rng.gen_range(1..buf.len() + 1);
 
         self.buf.write(&buf[..len])
     }
@@ -109,7 +110,9 @@ impl ::client::HttpStream for HttpBuffer {
     type Error = io::Error;
 
     /// Returns `Ok(self)`.
-    fn finish(self) -> Result<Self, io::Error> { Ok(self) }
+    fn finish(self) -> Result<Self, io::Error> {
+        Ok(self)
+    }
 }
 
 impl fmt::Debug for HttpBuffer {
@@ -159,7 +162,7 @@ impl<'a> Read for ServerRequest<'a> {
         }
 
         // Simulate the randomness of a network connection by not always reading everything
-        let len = self.rng.gen_range(1, out.len() + 1);
+        let len = self.rng.gen_range(1..out.len() + 1);
         self.data.read(&mut out[..len])
     }
 }
@@ -168,7 +171,9 @@ impl<'a> Read for ServerRequest<'a> {
 impl<'a> ::server::HttpRequest for ServerRequest<'a> {
     type Body = Self;
 
-    fn multipart_boundary(&self) -> Option<&str> { Some(self.boundary) }
+    fn multipart_boundary(&self) -> Option<&str> {
+        Some(self.boundary)
+    }
 
     fn body(self) -> Self::Body {
         self
@@ -185,7 +190,8 @@ impl<'s, W> StdoutTee<'s, W> {
     /// Constructor
     pub fn new(inner: W, stdout: &'s io::Stdout) -> Self {
         Self {
-            inner, stdout: stdout.lock(),
+            inner,
+            stdout: stdout.lock(),
         }
     }
 }


### PR DESCRIPTION
This fixes #137 and bumps the version of [https://crates.io/crates/rand](rand) and fixes these breaking changes from 0.7 to 0.8:

- gen_range() takes one arg (the range), not two (lower/upper bounds)
- Some methods return u8 instead of char. Fixed by using `char::from`

I'm happy to work with you on getting any edits made. I think this could merit a patch bump to 0.17.2.