### PR TITLE
[Fixes #143] Replace deprecated `twoway` with `memchr`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ safemem = { version = "0.3", optional = true }
 tempfile = "3"
 clippy = { version = ">=0.0, <0.1", optional = true}
 
-#Server Dependencies
+# Server Dependencies
 buf_redux = { version = "0.8", optional = true, default-features = false }
 httparse = { version = "1.2", optional = true }
-twoway = { version = "0.1", optional = true }
+memchr = { version = "2.5", optional = true }
 quick-error = { version = "1.2", optional = true }
 
 # Optional Integrations
@@ -48,7 +48,7 @@ env_logger = "0.5"
 [features]
 client = []
 default = ["client", "hyper", "iron", "mock", "nickel", "server", "tiny_http"]
-server = ["buf_redux", "httparse", "quick-error", "safemem", "twoway"]
+server = ["buf_redux", "httparse", "quick-error", "safemem", "memchr"]
 mock = []
 nightly = []
 bench = []

--- a/README.md
+++ b/README.md
@@ -67,10 +67,9 @@ to `std::io::BufReader`.)
 
 Fast, zero-copy HTTP header parsing, used to read field headers in `multipart/form-data` request bodies.
 
-### [twoway ![](https://img.shields.io/crates/v/twoway.svg)](https://crates.io/crates/twoway)
+### [memchr ![](https://img.shields.io/crates/v/memchr.svg)](https://crates.io/crates/memchr)
 
-Fast string and byte-string search. Used to find boundaries in the request body. Uses SIMD acceleration
-when possible.
+The library provides heavily optimized routines for string search primitives.
 
 ## License
 

--- a/src/server/boundary.rs
+++ b/src/server/boundary.rs
@@ -11,7 +11,7 @@ use ::safemem;
 
 use super::buf_redux::BufReader;
 use super::buf_redux::policy::MinBuffered;
-use super::twoway;
+use super::memchr::memmem;
 
 use std::cmp;
 use std::borrow::Borrow;
@@ -198,7 +198,7 @@ impl<R> BoundaryReader<R> where R: Read {
 
 /// Find the boundary occurrence or the highest length to safely yield
 fn find_boundary(buf: &[u8], boundary: &[u8]) -> Result<usize, usize> {
-    if let Some(idx) = twoway::find_bytes(buf, boundary) {
+    if let Some(idx) = memmem::find(buf, boundary) { 
         return Ok(idx);
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,7 +13,7 @@
 
 pub extern crate buf_redux;
 extern crate httparse;
-extern crate twoway;
+extern crate memchr;
 
 use std::borrow::Borrow;
 use std::io::prelude::*;


### PR DESCRIPTION
The author of [`twoway`](https://docs.rs/twoway/latest/twoway/) marked it as deprecated. This PR replaces it with maintained [`memchr`](https://docs.rs/memchr/2.5.0/memchr/index.html) crate.